### PR TITLE
Bugfix/3651 364 right component and chevron together

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,28 +4,24 @@
 
 ### Fixed
 
--   DOM nesting console warnings in `<InfoListItem>`'s `title`, `subtitle` and `info` props ([#644](https://github.com/brightlayer-ui/react-component-library/issues/644)).
--   Rendering of chevron and right component in `<InfoListItem>` at the same time ([#364](https://github.com/brightlayer-ui/react-component-library/issues/364)).
-
-### Updated
-
--   `<DrawerNavItem>` to pass `chevron` and `chevronColor` props to `<InfoListItem>` ([#364](https://github.com/brightlayer-ui/react-component-library/issues/364)).
+-   DOM nesting console warnings in `<InfoListItem>`'s `title`, `subtitle` and `info` props ([#644](https://github.com/etn-ccis/blui-react-component-library/issues/644)).
+-   Rendering of chevron and right component in `<InfoListItem>` at the same time ([#364](https://github.com/etn-ccis/blui-react-component-library/issues/364)).
 
 ## v6.1.2 (December 7, 2022)
 
 ### Updated
 
--   Remove dependency on @mui/styles ([#633](https://github.com/brightlayer-ui/react-component-library/issues/633)).
+-   Remove dependency on @mui/styles ([#633](https://github.com/etn-ccis/blui-react-component-library/issues/633)).
 
 ## v6.1.1 (November 1, 2022)
 
 ### Fixed
 
--   `hideContentOnCollapse` prop of `<DrawerFooter>` not hiding footer content ([#484](https://github.com/brightlayer-ui/react-component-library/issues/484)).
--   Temporary drawer rendering, due to incorrectly passing open prop ([#486](https://github.com/brightlayer-ui/react-component-library/issues/486)).
--   `activeItemFontColor`, `activeItemIconColor` prop of `<DrawerRailItem>` not updating `font color` and `icon color` of active rail item. ([#486](https://github.com/brightlayer-ui/react-component-library/issues/486)).
--   `condensed` prop of `<DrawerRailItem>` not appling height and width `56X56` to all rail items. ([#541](https://github.com/brightlayer-ui/react-component-library/issues/541)).
--   Styling of `nonClickableIcon` in `<DrawerHeader>` not applying properly ([#562](https://github.com/brightlayer-ui/react-component-library/issues/562)).
+-   `hideContentOnCollapse` prop of `<DrawerFooter>` not hiding footer content ([#484](https://github.com/etn-ccis/blui-react-component-library/issues/484)).
+-   Temporary drawer rendering, due to incorrectly passing open prop ([#486](https://github.com/etn-ccis/blui-react-component-library/issues/486)).
+-   `activeItemFontColor`, `activeItemIconColor` prop of `<DrawerRailItem>` not updating `font color` and `icon color` of active rail item. ([#486](https://github.com/etn-ccis/blui-react-component-library/issues/486)).
+-   `condensed` prop of `<DrawerRailItem>` not appling height and width `56X56` to all rail items. ([#541](https://github.com/etn-ccis/blui-react-component-library/issues/541)).
+-   Styling of `nonClickableIcon` in `<DrawerHeader>` not applying properly ([#562](https://github.com/etn-ccis/blui-react-component-library/issues/562)).
 -   `animationDuration` not being applied properly to `<AppBar>` component.
 -   DOM Nesting warnings when passing custom content to `title` or `description` of `<EmptyState>`.
 
@@ -39,14 +35,14 @@
 
 ### Changed
 
--   Components are now built to work with Material UI v5 ([#352](https://github.com/brightlayer-ui/react-component-library/issues/352)).
--   In `<Hero>` component, `fontSize`, `value`, `valueIcon`, `valueColor` and `units` props have been replaced by `ChannelValueProps` prop, which will allow you to specify any props on the underlying `<ChannelValue>` component. ([#365](https://github.com/brightlayer-ui/react-component-library/issues/365)).
+-   Components are now built to work with Material UI v5 ([#352](https://github.com/etn-ccis/blui-react-component-library/issues/352)).
+-   In `<Hero>` component, `fontSize`, `value`, `valueIcon`, `valueColor` and `units` props have been replaced by `ChannelValueProps` prop, which will allow you to specify any props on the underlying `<ChannelValue>` component. ([#365](https://github.com/etn-ccis/blui-react-component-library/issues/365)).
 
 ### Removed
 
 -   Quick set options for fontSize ('normal' and 'small') have been removed in the `<Hero>` / `<ChannelValue>` components — if you were using these options previously, they can be replaced with '1.25rem' and '1rem', respectively, e.g.:
     -   `<Hero ChannelValueProps={{ fontSize: '1rem' }} />`
--   DropdownToolbar. You should switch to using the `<ToolbarMenu>` component inside of a MUI Toolbar instead. ([#353](https://github.com/brightlayer-ui/react-component-library/issues/353)).
+-   DropdownToolbar. You should switch to using the `<ToolbarMenu>` component inside of a MUI Toolbar instead. ([#353](https://github.com/etn-ccis/blui-react-component-library/issues/353)).
 
 ## v5.4.0 (February 8, 2022)
 
@@ -54,17 +50,17 @@
 
 -   Added `chevronColor` property to `<InfoListItem>` and SharedProps of `<Drawer>`.
 -   Added class override for `chevron` on `<InfoListItem>` and `<DrawerNavItem>`.
--   Added `titleDivider` property onto `<DrawerNavGroup>`. ([#315](https://github.com/brightlayer-ui/react-component-library/issues/315))
--   Added 1rem default padding to the root styles of `<EmptyState>`. ([#320](https://github.com/brightlayer-ui/react-component-library/issues/320))
--   Added new property `unitSpace` to `<ChannelValue>` to manage spacing between the value and units. ([#350](https://github.com/brightlayer-ui/react-component-library/issues/350))
--   Added `<ToolbarMenu>` component. ([#351](https://github.com/brightlayer-ui/react-component-library/issues/351))
+-   Added `titleDivider` property onto `<DrawerNavGroup>`. ([#315](https://github.com/etn-ccis/blui-react-component-library/issues/315))
+-   Added 1rem default padding to the root styles of `<EmptyState>`. ([#320](https://github.com/etn-ccis/blui-react-component-library/issues/320))
+-   Added new property `unitSpace` to `<ChannelValue>` to manage spacing between the value and units. ([#350](https://github.com/etn-ccis/blui-react-component-library/issues/350))
+-   Added `<ToolbarMenu>` component. ([#351](https://github.com/etn-ccis/blui-react-component-library/issues/351))
 -   Added Deprecation warnings for DropdownToolbar component that will be removed in version 6.0.0.
 
 ## v5.3.3 (December 6, 2021)
 
 ### Fixed
 
--   Avoid rendering of HTML elements in `<InfoListItem>`'s DOM tree when `subtitle` or `info` prop is not available. ([#318](https://github.com/brightlayer-ui/react-component-library/issues/318))
+-   Avoid rendering of HTML elements in `<InfoListItem>`'s DOM tree when `subtitle` or `info` prop is not available. ([#318](https://github.com/etn-ccis/blui-react-component-library/issues/318))
 
 ## v5.3.2 (November 11, 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 ### Fixed
 
 -   DOM nesting console warnings in `<InfoListItem>`'s `title`, `subtitle` and `info` props ([#644](https://github.com/brightlayer-ui/react-component-library/issues/644)).
+-   Rendering of chevron and right component in `<InfoListItem>` at the same time ([#364](https://github.com/brightlayer-ui/react-component-library/issues/364)).
+
+### Updated
+
+-   `<DrawerNavItem>` to pass `chevron` and `chevronColor` props to `<InfoListItem>` ([#364](https://github.com/brightlayer-ui/react-component-library/issues/364)).
 
 ## v6.1.2 (December 7, 2022)
 

--- a/components/src/core/Drawer/DrawerNavItem/DrawerNavItem.tsx
+++ b/components/src/core/Drawer/DrawerNavItem/DrawerNavItem.tsx
@@ -469,7 +469,7 @@ const DrawerNavItemRender: React.ForwardRefRenderFunction<HTMLElement, DrawerNav
                         fontColor={active ? activeItemFontColor : itemFontColor}
                         icon={icon}
                         iconColor={active ? activeItemIconColor : itemIconColor}
-                        chevron={chevron}
+                        chevron={chevron && !items && !children}
                         chevronColor={chevronColor}
                         rightComponent={
                             (actionComponent || rightComponent) && (

--- a/components/src/core/Drawer/DrawerNavItem/DrawerNavItem.tsx
+++ b/components/src/core/Drawer/DrawerNavItem/DrawerNavItem.tsx
@@ -8,7 +8,6 @@ import List from '@mui/material/List';
 import Collapse from '@mui/material/Collapse';
 import { InfoListItem, InfoListItemProps as BLUIInfoListItemProps } from '../../InfoListItem';
 import ArrowDropDown from '@mui/icons-material/ArrowDropDown';
-import ChevronRight from '@mui/icons-material/ChevronRight';
 import ExpandMore from '@mui/icons-material/ExpandMore';
 import { NavItemSharedStyleProps, NavItemSharedStylePropTypes, SharedStyleProps, SharedStylePropTypes } from '../types';
 import color from 'color';

--- a/components/src/core/Drawer/DrawerNavItem/DrawerNavItem.tsx
+++ b/components/src/core/Drawer/DrawerNavItem/DrawerNavItem.tsx
@@ -171,15 +171,6 @@ const InfoListItemRoot = styled(InfoListItem, {
     })
 );
 
-const Chevron = styled(ChevronRight, {
-    name: 'drawer-nav-item',
-    slot: 'chevron',
-    shouldForwardProp: (prop) => prop !== 'chevronColor',
-})<Pick<DrawerNavItemProps, 'chevronColor'>>(({ chevronColor, theme }) => ({
-    color: chevronColor ? chevronColor : theme.palette.text.secondary,
-    transform: theme.direction === 'rtl' ? 'scaleX(-1)' : '',
-}));
-
 const ActiveComponent = styled(Box, {
     name: 'drawer-nav-item',
     slot: 'active-component',
@@ -265,9 +256,7 @@ const DrawerNavItemRender: React.ForwardRefRenderFunction<HTMLElement, DrawerNav
         nestedDivider,
         notifyActiveParent = (): void => {},
         onClick,
-        rightComponent = props.chevron && !props.items && !props.children ? (
-            <Chevron chevronColor={chevronColor} className={cx(defaultClasses.chevron, classes.chevron)} />
-        ) : undefined,
+        rightComponent,
         ripple = true,
         statusColor,
         subtitle: itemSubtitle,
@@ -481,6 +470,8 @@ const DrawerNavItemRender: React.ForwardRefRenderFunction<HTMLElement, DrawerNav
                         fontColor={active ? activeItemFontColor : itemFontColor}
                         icon={icon}
                         iconColor={active ? activeItemIconColor : itemIconColor}
+                        chevron={chevron}
+                        chevronColor={chevronColor}
                         rightComponent={
                             (actionComponent || rightComponent) && (
                                 <div

--- a/components/src/core/InfoListItem/InfoListItem.tsx
+++ b/components/src/core/InfoListItem/InfoListItem.tsx
@@ -194,18 +194,21 @@ const InfoListItemRender: React.ForwardRefRenderFunction<unknown, InfoListItemPr
     }, [icon, avatar, hidePadding, combine]);
 
     const getRightComponent = useCallback((): JSX.Element | undefined => {
-        if (rightComponent) {
-            return <RightComponent className={combine('rightComponent')}>{rightComponent}</RightComponent>;
-        } else if (chevron) {
-            return (
-                <InfoListItemChevron
-                    chevronColor={chevronColor}
-                    color={'inherit'}
-                    role={'button'}
-                    className={combine('chevron')}
-                />
-            );
-        }
+        return (
+            <>
+                {rightComponent && (
+                    <RightComponent className={combine('rightComponent')}>{rightComponent}</RightComponent>
+                )}
+                {chevron && (
+                    <InfoListItemChevron
+                        chevronColor={chevronColor}
+                        color={'inherit'}
+                        role={'button'}
+                        className={combine('chevron')}
+                    />
+                )}
+            </>
+        );
     }, [rightComponent, chevron, combine]);
 
     const getSeparator = useCallback(

--- a/components/src/core/InfoListItem/InfoListItem.tsx
+++ b/components/src/core/InfoListItem/InfoListItem.tsx
@@ -193,8 +193,8 @@ const InfoListItemRender: React.ForwardRefRenderFunction<unknown, InfoListItemPr
         }
     }, [icon, avatar, hidePadding, combine]);
 
-    const getRightComponent = useCallback((): JSX.Element | undefined => {
-        return (
+    const getRightComponent = useCallback(
+        (): JSX.Element | undefined => (
             <>
                 {rightComponent && (
                     <RightComponent className={combine('rightComponent')}>{rightComponent}</RightComponent>
@@ -208,8 +208,9 @@ const InfoListItemRender: React.ForwardRefRenderFunction<unknown, InfoListItemPr
                     />
                 )}
             </>
-        );
-    }, [rightComponent, chevron, combine]);
+        ),
+        [rightComponent, chevron, combine]
+    );
 
     const getSeparator = useCallback(
         (): JSX.Element => (


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #364 BLUI-3651

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Rendered chevron and right component separately in info list item
- Refactored drawer nav item to pass chevron, chevronColor and rightComponent props 

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
<img width="1792" alt="Screenshot 2022-12-27 at 1 21 46 PM" src="https://user-images.githubusercontent.com/25982779/209632496-d7001946-57e4-45c3-bc9f-efce7cc3db72.png">

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- Checkout [bugfix/i3651-364-infolistitem-chevron-right-comp](https://github.com/brightlayer-ui/react-showcase-demo/tree/bugfix/i3651-364-infolistitem-chevron-right-comp) branch in react showcase demo
- build the components with yarn build
- paste the dist folder contents to showcase demo's node_modules/@brighlayer-ui/react-components/
- cd demos/showcase
- yarn start
