### PR TITLE
Bugfix/3717 672 replace old GitHub repo with ghe

### DIFF
--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -15,5 +15,5 @@ jobs:
         uses: thollander/actions-comment-pull-request@v1
         with:
            message: 'Thank you for the master pull request. 👍 Please be sure this pull request is for the master branch. The master branch is used for items that are ready for publishing.
-           The dev branch is our working branch for all issues and enhancements. Please read our [Contributing Guidelines](https://github.com/brightlayer-ui/.github/blob/dev/CONTRIBUTING.md) for more information.'
+           The dev branch is our working branch for all issues and enhancements. Please read our [Contributing Guidelines](https://github.com/etn-ccis/blui-doc-it/blob/master/src/docs/community/contributing-guideline.md) for more information.'
            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "demos/showcase"]
 	path = demos/showcase
-	url = https://github.com/brightlayer-ui/react-showcase-demo
+	url = https://github.com/etn-ccis/blui-react-native-showcase-demo
 	branch = dev

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "demos/showcase"]
 	path = demos/showcase
-	url = https://github.com/etn-ccis/blui-react-native-showcase-demo
+	url = https://github.com/etn-ccis/blui-react-showcase-demo
 	branch = dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 6.1.3-alpha.0 (Unreleased)
+## 6.1.3 (Unreleased)
 
 ### Fixed
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @jeffvg @emclaug2 @huayunh @daileytj
+* @JeffGreiner-eaton @huayunh @daileytj @surajeaton

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 This is a library of re-usable React components for use in Brightlayer UI applications. For the most part, these components are meant to simplify building your application by providing drop-in components that implement common use cases in Brightlayer UI and eliminate the need for multiple teams to build their own components for these.
 
-Refer to the [Component Library](https://brightlayer-ui-components.github.io/react) API documentation site for a list of available components or see the repository [documentation](https://github.com/brightlayer-ui/react-component-library/tree/master/docs) for each individual component.
+Refer to the [Component Library](https://brightlayer-ui-components.github.io/react) API documentation site for a list of available components or see the repository [documentation](https://github.com/etn-ccis/blui-react-component-library/tree/master/docs) for each individual component.
 
 ## Installation
 
@@ -22,7 +22,7 @@ yarn add @brightlayer-ui/react-components
 To work with this library, first clone down the repository and install dependencies:
 
 ```shell
-git clone https://github.com/brightlayer-ui/react-component-library
+git clone https://github.com/etn-ccis/blui-react-component-library
 cd react-component-library
 yarn initialize
 ```
@@ -58,7 +58,7 @@ from the root directory.
 
 ## Using the Components
 
-See the [documentation](https://github.com/brightlayer-ui/react-component-library/tree/master/docs) for information on using these components.
+See the [documentation](https://github.com/etn-ccis/blui-react-component-library/tree/master/docs) for information on using these components.
 
 ## Browser Support
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ We recommend using this library in conjunction with [@brightlayer-ui/react-theme
 ## Running the demo projects
 
 This repository comes with two demo projects found within the `/demos` folder.
-The first is a [Storybook](https://storybook.js.org/) application that allows you to see the components in isolation and interact with their properties. The second is a Showcase project (from [react-showcase-demo](https://github.com/brightlayer-ui/react-showcase-demo)) that shows a combination of components in the context of a realistic interface.
+The first is a [Storybook](https://storybook.js.org/) application that allows you to see the components in isolation and interact with their properties. The second is a Showcase project (from [react-showcase-demo](https://github.com/etn-ccis/blui-react-native-showcase-demo)) that shows a combination of components in the context of a realistic interface.
 
 You can build, link, and start the demo applications in a single step by calling either
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Brightlayer UI React Components
 
-[![](https://img.shields.io/circleci/project/github/brightlayer-ui/react-component-library/master.svg?style=flat)](https://circleci.com/gh/brightlayer-ui/react-component-library/tree/master)
-![npm](https://img.shields.io/npm/v/@brightlayer-ui/react-components?label=%40brightlayer-ui%2Freact-components) [![codecov](https://codecov.io/gh/brightlayer-ui/react-component-library/branch/master/graph/badge.svg?token=HQFW5YF7WP)](https://codecov.io/gh/brightlayer-ui/react-component-library)
+[![](https://img.shields.io/circleci/project/github/etn-ccis/blui-react-component-library/master.svg?style=flat)](https://circleci.com/gh/etn-ccis/blui-react-component-library/tree/master)
+![npm](https://img.shields.io/npm/v/@brightlayer-ui/react-components?label=%40brightlayer-ui%2Freact-components) [![codecov](https://codecov.io/gh/etn-ccis/blui-react-component-library/branch/master/graph/badge.svg?token=HQFW5YF7WP)](https://codecov.io/gh/etn-ccis/blui-react-component-library)
 
 This is a library of re-usable React components for use in Brightlayer UI applications. For the most part, these components are meant to simplify building your application by providing drop-in components that implement common use cases in Brightlayer UI and eliminate the need for multiple teams to build their own components for these.
 
-Refer to the [Component Library](https://brightlayer-ui-components.github.io/react) API documentation site for a list of available components or see the repository [documentation](https://github.com/etn-ccis/blui-react-component-library/tree/master/docs) for each individual component.
+Refer to the [Component Library](https://brightlayer-ui-components.github.io/react) API documentation site for a list of available components and the document for each individual component.
 
 ## Installation
 
@@ -35,7 +35,7 @@ yarn build
 
 ## Using with @brightlayer-ui/react-themes
 
-We recommend using this library in conjunction with [@brightlayer-ui/react-themes](https://www.npmjs.com/package/@brightlayer-ui/react-themes). If you are using version 6.0.0+ of the Brightlayer UI themes, you must upgrade to at least version 5.1.0 of @brightlayer-ui/react-components or you may see some unintended default styles on some components.
+We recommend using this library in conjunction with [@brightlayer-ui/react-themes](https://www.npmjs.com/package/@brightlayer-ui/react-themes). If you are using version 6.0.0+ of the Brightlayer UI themes, you must upgrade to at least version 5.1.0 of @brightlayer-ui/react-components, or you may see some unintended default styles on some components.
 
 ## Running the demo projects
 
@@ -58,7 +58,7 @@ from the root directory.
 
 ## Using the Components
 
-See the [documentation](https://github.com/etn-ccis/blui-react-component-library/tree/master/docs) for information on using these components.
+See the [documentation](https://brightlayer-ui-components.github.io/react) for information on using these components.
 
 ## Browser Support
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ We recommend using this library in conjunction with [@brightlayer-ui/react-theme
 ## Running the demo projects
 
 This repository comes with two demo projects found within the `/demos` folder.
-The first is a [Storybook](https://storybook.js.org/) application that allows you to see the components in isolation and interact with their properties. The second is a Showcase project (from [react-showcase-demo](https://github.com/etn-ccis/blui-react-native-showcase-demo)) that shows a combination of components in the context of a realistic interface.
+The first is a [Storybook](https://storybook.js.org/) application that allows you to see the components in isolation and interact with their properties. The second is a Showcase project (from [react-showcase-demo](https://github.com/etn-ccis/blui-react-showcase-demo)) that shows a combination of components in the context of a realistic interface.
 
 You can build, link, and start the demo applications in a single step by calling either
 

--- a/components/LICENSES.json
+++ b/components/LICENSES.json
@@ -1,8 +1,8 @@
 {
     "@brightlayer-ui/colors@3.1.1": {
         "licenses": "BSD-3-Clause",
-        "repository": "https://github.com/brightlayer-ui/colors",
-        "licenseUrl": "https://github.com/brightlayer-ui/colors/raw/master/LICENSE",
+        "repository": "https://github.com/etn-ccis/blui-colors",
+        "licenseUrl": "https://github.com/etn-ccis/blui-colors/raw/master/LICENSE",
         "parents": "@brightlayer-ui/react-components"
     },
     "@emotion/css@11.9.0": {

--- a/components/package.json
+++ b/components/package.json
@@ -59,7 +59,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/brightlayer-ui/react-component-library"
+        "url": "https://github.com/etn-ccis/blui-react-component-library"
     },
     "keywords": [
         "react",
@@ -67,9 +67,9 @@
         "brightlayer-ui"
     ],
     "bugs": {
-        "url": "https://github.com/brightlayer-ui/react-component-library/issues"
+        "url": "https://github.com/etn-ccis/blui-react-component-library/issues"
     },
-    "homepage": "https://github.com/brightlayer-ui/react-component-library#readme",
+    "homepage": "https://github.com/etn-ccis/blui-react-component-library#readme",
     "directories": {
         "doc": "docs"
     },

--- a/components/src/core/Hero/Hero.tsx
+++ b/components/src/core/Hero/Hero.tsx
@@ -146,7 +146,7 @@ const HeroRender: React.ForwardRefRenderFunction<unknown, HeroProps> = (props: H
 /**
  * [Hero](https://brightlayer-ui-components.github.io/react/components/hero) component
  *
- * The `<Hero>` component displays a particular icon, value/units, and a label. The icon property will accept any valid component - this will typically be a Material icon, [Brightlayer UI icon](https://github.com/brightlayer-ui/icons), or [Progress Icon](https://github.com/brightlayer-ui/icons/tree/master/progress). It will also accept Text/Emoji values.
+ * The `<Hero>` component displays a particular icon, value/units, and a label. The icon property will accept any valid component - this will typically be a Material icon, [Brightlayer UI icon](https://github.com/etn-ccis/blui-icons), or [Progress Icon](https://github.com/etn-ccis/blui-progress-icons). It will also accept Text/Emoji values.
  */
 export const Hero = React.forwardRef(HeroRender);
 

--- a/demos/storybook/stories/welcome.stories.tsx
+++ b/demos/storybook/stories/welcome.stories.tsx
@@ -101,7 +101,7 @@ stories.add('Brightlayer UI React Components', () => {
                         color="primary"
                         className={classes.link}
                         target={'_blank'}
-                        href={'https://github.com/brightlayer-ui/react-component-library'}
+                        href={'https://github.com/etn-ccis/blui-react-component-library'}
                         startIcon={
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" className={classes.githubIcon}>
                                 <title>github</title>

--- a/docs/src/componentDocs/AppBar/markdown/AppBarAPIDocs.mdx
+++ b/docs/src/componentDocs/AppBar/markdown/AppBarAPIDocs.mdx
@@ -99,7 +99,7 @@ You can override the default styles used by Brightlayer UI by:
 -   using the Global CSS Class in your main stylesheet
 
 {/* prettier-ignore */}
-<p>For more details on styling options check out our <a href={`https://github.com/brightlayer-ui/react-component-library/blob/${DOCS_BRANCH}/docs/src/shared/markdown/StyleOverridesGuide.md`}>Styling Guide</a>.</p>
+<p>For more details on styling options check out our <a href={`https://github.com/etn-ccis/blui-react-component-library/blob/${DOCS_BRANCH}/docs/src/shared/markdown/StyleOverridesGuide.md`}>Styling Guide</a>.</p>
 
 <Box>
 

--- a/docs/src/componentDocs/ChannelValue/markdown/ChannelValueAPIDocs.mdx
+++ b/docs/src/componentDocs/ChannelValue/markdown/ChannelValueAPIDocs.mdx
@@ -71,7 +71,7 @@ You can override the default styles used by Brightlayer UI by:
 -   using the Global CSS Class in your main stylesheet
 
 {/* prettier-ignore */}
-<p>For more details on styling options check out our <a href={`https://github.com/brightlayer-ui/react-component-library/blob/${DOCS_BRANCH}/docs/src/shared/markdown/StyleOverridesGuide.md`}>Styling Guide</a>.</p>
+<p>For more details on styling options check out our <a href={`https://github.com/etn-ccis/blui-react-component-library/blob/${DOCS_BRANCH}/docs/src/shared/markdown/StyleOverridesGuide.md`}>Styling Guide</a>.</p>
 
 <Box>
 

--- a/docs/src/componentDocs/Drawer/markdown/DrawerAPIDocs.mdx
+++ b/docs/src/componentDocs/Drawer/markdown/DrawerAPIDocs.mdx
@@ -88,7 +88,7 @@ You can override the default styles used by Brightlayer UI by:
 -   using the Global CSS Class in your main stylesheet
 
 {/* prettier-ignore */}
-<p>For more details on styling options check out our <a href={`https://github.com/brightlayer-ui/react-component-library/blob/${DOCS_BRANCH}/docs/src/shared/markdown/StyleOverridesGuide.md`}>Styling Guide</a>.</p>
+<p>For more details on styling options check out our <a href={`https://github.com/etn-ccis/blui-react-component-library/blob/${DOCS_BRANCH}/docs/src/shared/markdown/StyleOverridesGuide.md`}>Styling Guide</a>.</p>
 
 <Box>
 

--- a/docs/src/componentDocs/DrawerFooter/markdown/DrawerFooterAPIDocs.mdx
+++ b/docs/src/componentDocs/DrawerFooter/markdown/DrawerFooterAPIDocs.mdx
@@ -28,7 +28,7 @@ You can override the default styles used by Brightlayer UI by:
 -   using the Global CSS Class in your main stylesheet
 
 {/* prettier-ignore */}
-<p>For more details on styling options check out our <a href={`https://github.com/brightlayer-ui/react-component-library/blob/${DOCS_BRANCH}/docs/src/shared/markdown/StyleOverridesGuide.md`}>Styling Guide</a>.</p>
+<p>For more details on styling options check out our <a href={`https://github.com/etn-ccis/blui-react-component-library/blob/${DOCS_BRANCH}/docs/src/shared/markdown/StyleOverridesGuide.md`}>Styling Guide</a>.</p>
 
 <Box  >
 

--- a/docs/src/componentDocs/DrawerHeader/markdown/DrawerHeaderAPIDocs.mdx
+++ b/docs/src/componentDocs/DrawerHeader/markdown/DrawerHeaderAPIDocs.mdx
@@ -54,7 +54,7 @@ You can override the default styles used by Brightlayer UI by:
 -   using the Global CSS Class in your main stylesheet
 
 {/* prettier-ignore */}
-<p>For more details on styling options check out our <a href={`https://github.com/brightlayer-ui/react-component-library/blob/${DOCS_BRANCH}/docs/src/shared/markdown/StyleOverridesGuide.md`}>Styling Guide</a>.</p>
+<p>For more details on styling options check out our <a href={`https://github.com/etn-ccis/blui-react-component-library/blob/${DOCS_BRANCH}/docs/src/shared/markdown/StyleOverridesGuide.md`}>Styling Guide</a>.</p>
 
 <Box>
 

--- a/docs/src/componentDocs/DrawerLayout/markdown/DrawerLayoutAPIDocs.mdx
+++ b/docs/src/componentDocs/DrawerLayout/markdown/DrawerLayoutAPIDocs.mdx
@@ -48,7 +48,7 @@ You can override the default styles used by Brightlayer UI by:
 -   using the Global CSS Class in your main stylesheet
 
 {/* prettier-ignore */}
-<p>For more details on styling options check out our <a href={`https://github.com/brightlayer-ui/react-component-library/blob/${DOCS_BRANCH}/docs/src/shared/markdown/StyleOverridesGuide.md`}>Styling Guide</a>.</p>
+<p>For more details on styling options check out our <a href={`https://github.com/etn-ccis/blui-react-component-library/blob/${DOCS_BRANCH}/docs/src/shared/markdown/StyleOverridesGuide.md`}>Styling Guide</a>.</p>
 
 <Box>
 

--- a/docs/src/componentDocs/DrawerNavGroup/markdown/DrawerNavGroupAPIDocs.mdx
+++ b/docs/src/componentDocs/DrawerNavGroup/markdown/DrawerNavGroupAPIDocs.mdx
@@ -54,7 +54,7 @@ You can override the default styles used by Brightlayer UI by:
     the Global CSS Class in your main stylesheet
 
 {/* prettier-ignore */}
-<p>For more details on styling options check out our <a href={`https://github.com/brightlayer-ui/react-component-library/blob/${DOCS_BRANCH}/docs/src/shared/markdown/StyleOverridesGuide.md`}>Styling Guide</a>.</p>
+<p>For more details on styling options check out our <a href={`https://github.com/etn-ccis/blui-react-component-library/blob/${DOCS_BRANCH}/docs/src/shared/markdown/StyleOverridesGuide.md`}>Styling Guide</a>.</p>
 
 <Box>
 

--- a/docs/src/componentDocs/DrawerRailItem/markdown/DrawerRailItemAPIDocs.mdx
+++ b/docs/src/componentDocs/DrawerRailItem/markdown/DrawerRailItemAPIDocs.mdx
@@ -55,7 +55,7 @@ You can override the default styles used by Brightlayer UI by:
 -   using the Global CSS Class in your main stylesheet
 
 {/* prettier-ignore */}
-<p>For more details on styling options check out our <a href={`https://github.com/brightlayer-ui/react-component-library/blob/${DOCS_BRANCH}/docs/src/shared/markdown/StyleOverridesGuide.md`}>Styling Guide</a>.</p>
+<p>For more details on styling options check out our <a href={`https://github.com/etn-ccis/blui-react-component-library/blob/${DOCS_BRANCH}/docs/src/shared/markdown/StyleOverridesGuide.md`}>Styling Guide</a>.</p>
 
 <Box>
 

--- a/docs/src/componentDocs/EmptyState/markdown/EmptyStateAPIDocs.mdx
+++ b/docs/src/componentDocs/EmptyState/markdown/EmptyStateAPIDocs.mdx
@@ -48,7 +48,7 @@ You can override the default styles used by Brightlayer UI by:
 -   using the Global CSS Class in your main stylesheet
 
 {/* prettier-ignore */}
-<p>For more details on styling options check out our <a href={`https://github.com/brightlayer-ui/react-component-library/blob/${DOCS_BRANCH}/docs/src/shared/markdown/StyleOverridesGuide.md`}>Styling Guide</a>.</p>
+<p>For more details on styling options check out our <a href={`https://github.com/etn-ccis/blui-react-component-library/blob/${DOCS_BRANCH}/docs/src/shared/markdown/StyleOverridesGuide.md`}>Styling Guide</a>.</p>
 
 <Box>
 

--- a/docs/src/componentDocs/Hero/markdown/HeroAPIDocs.mdx
+++ b/docs/src/componentDocs/Hero/markdown/HeroAPIDocs.mdx
@@ -24,7 +24,7 @@ The Brightlayer UI `<Hero>` components are used to call attention to particular 
     />
 </Box>
 
-The `<Hero>` component displays a particular icon, value/units, and a label. The icon property will accept any valid component - this will typically be a Material icon, [Brightlayer UI icon](https://github.com/brightlayer-ui/icons), or [Progress Icon](https://github.com/brightlayer-ui/progress-icons). It will also accept Text/Emoji values.
+The `<Hero>` component displays a particular icon, value/units, and a label. The icon property will accept any valid component - this will typically be a Material icon, [Brightlayer UI icon](https://github.com/etn-ccis/blui-icons), or [Progress Icon](https://github.com/etn-ccis/blui-progress-icons). It will also accept Text/Emoji values.
 
 The value section of the Hero utilizes a [`<ChannelValue>`](/components/channel-value/api-docs) component. To display a single simple value, the information can be passed using ChannelValueProps which will allow you to specify any props on the underlying `<ChannelValue>` component. For more complex values (such as a duration that displays hours and minutes), you can pass in `<ChannelValue>` components as children and they will be displayed inline.
 

--- a/docs/src/componentDocs/Hero/markdown/HeroAPIDocs.mdx
+++ b/docs/src/componentDocs/Hero/markdown/HeroAPIDocs.mdx
@@ -73,7 +73,7 @@ You can override the default styles used by Brightlayer UI by:
 -   using the Global CSS Class in your main stylesheet
 
 {/* prettier-ignore */}
-<p>For more details on styling options check out our <a href={`https://github.com/brightlayer-ui/react-component-library/blob/${DOCS_BRANCH}/docs/src/shared/markdown/StyleOverridesGuide.md`}>Styling Guide</a>.</p>
+<p>For more details on styling options check out our <a href={`https://github.com/etn-ccis/blui-react-component-library/blob/${DOCS_BRANCH}/docs/src/shared/markdown/StyleOverridesGuide.md`}>Styling Guide</a>.</p>
 
 <Box>
 

--- a/docs/src/componentDocs/InfoListItem/markdown/InfoListItemAPIDocs.mdx
+++ b/docs/src/componentDocs/InfoListItem/markdown/InfoListItemAPIDocs.mdx
@@ -68,7 +68,7 @@ You can override the default styles used by Brightlayer UI by:
 -   using the Global CSS Class in your main stylesheet
 
 {/* prettier-ignore */}
-<p>For more details on styling options check out our <a href={`https://github.com/brightlayer-ui/react-component-library/blob/${DOCS_BRANCH}/docs/src/shared/markdown/StyleOverridesGuide.md`}>Styling Guide</a>.</p>
+<p>For more details on styling options check out our <a href={`https://github.com/etn-ccis/blui-react-component-library/blob/${DOCS_BRANCH}/docs/src/shared/markdown/StyleOverridesGuide.md`}>Styling Guide</a>.</p>
 
 <Box>
 

--- a/docs/src/componentDocs/ListItemTag/markdown/ListItemTagAPIDocs.mdx
+++ b/docs/src/componentDocs/ListItemTag/markdown/ListItemTagAPIDocs.mdx
@@ -44,7 +44,7 @@ You can override the default styles used by Brightlayer UI by:
 -   using the Global CSS Class in your main stylesheet
 
 {/* prettier-ignore */}
-<p>For more details on styling options check out our <a href={`https://github.com/brightlayer-ui/react-component-library/blob/${DOCS_BRANCH}/docs/src/shared/markdown/StyleOverridesGuide.md`}>Styling Guide</a>.</p>
+<p>For more details on styling options check out our <a href={`https://github.com/etn-ccis/blui-react-component-library/blob/${DOCS_BRANCH}/docs/src/shared/markdown/StyleOverridesGuide.md`}>Styling Guide</a>.</p>
 
 <Box>
 | Name | Global CSS Class      | Description                        |

--- a/docs/src/componentDocs/ScoreCard/markdown/ScoreCardAPIDocs.mdx
+++ b/docs/src/componentDocs/ScoreCard/markdown/ScoreCardAPIDocs.mdx
@@ -67,7 +67,7 @@ You can override the default styles used by Brightlayer UI by:
 -   using the Global CSS Class in your main stylesheet
 
 {/* prettier-ignore */}
-<p>For more details on styling options check out our <a href={`https://github.com/brightlayer-ui/react-component-library/blob/${DOCS_BRANCH}/docs/src/shared/markdown/StyleOverridesGuide.md`}>Styling Guide</a>.</p>
+<p>For more details on styling options check out our <a href={`https://github.com/etn-ccis/blui-react-component-library/blob/${DOCS_BRANCH}/docs/src/shared/markdown/StyleOverridesGuide.md`}>Styling Guide</a>.</p>
 
 <Box>
 

--- a/docs/src/componentDocs/Spacer/markdown/SpacerAPIDocs.mdx
+++ b/docs/src/componentDocs/Spacer/markdown/SpacerAPIDocs.mdx
@@ -47,7 +47,7 @@ You can override the default styles used by Brightlayer UI by:
 -   using the Global CSS Class in your main stylesheet
 
 {/* prettier-ignore */}
-<p>For more details on styling options check out our <a href={`https://github.com/brightlayer-ui/react-component-library/blob/${DOCS_BRANCH}/docs/src/shared/markdown/StyleOverridesGuide.md`}>Styling Guide</a>.</p>
+<p>For more details on styling options check out our <a href={`https://github.com/etn-ccis/blui-react-component-library/blob/${DOCS_BRANCH}/docs/src/shared/markdown/StyleOverridesGuide.md`}>Styling Guide</a>.</p>
 
 <Box>
 

--- a/docs/src/componentDocs/ThreeLiner/markdown/ThreeLinerAPIDocs.mdx
+++ b/docs/src/componentDocs/ThreeLiner/markdown/ThreeLinerAPIDocs.mdx
@@ -28,7 +28,7 @@ You can override the default styles used by Brightlayer UI by:
 -   using the Global CSS Class in your main stylesheet
 
 {/* prettier-ignore */}
-<p>For more details on styling options check out our <a href={`https://github.com/brightlayer-ui/react-component-library/blob/${DOCS_BRANCH}/docs/src/shared/markdown/StyleOverridesGuide.md`}>Styling Guide</a>.</p>
+<p>For more details on styling options check out our <a href={`https://github.com/etn-ccis/blui-react-component-library/blob/${DOCS_BRANCH}/docs/src/shared/markdown/StyleOverridesGuide.md`}>Styling Guide</a>.</p>
 
 <Box>
 

--- a/docs/src/componentDocs/ToolbarMenu/markdown/ToolbarMenuAPIDocs.mdx
+++ b/docs/src/componentDocs/ToolbarMenu/markdown/ToolbarMenuAPIDocs.mdx
@@ -49,7 +49,7 @@ You can override the default styles used by Brightlayer UI by:
 -   using the Global CSS Class in your main stylesheet
 
 {/* prettier-ignore */}
-<p>For more details on styling options check out our <a href={`https://github.com/brightlayer-ui/react-component-library/blob/${DOCS_BRANCH}/docs/src/shared/markdown/StyleOverridesGuide.md`}>Styling Guide</a>.</p>
+<p>For more details on styling options check out our <a href={`https://github.com/etn-ccis/blui-react-component-library/blob/${DOCS_BRANCH}/docs/src/shared/markdown/StyleOverridesGuide.md`}>Styling Guide</a>.</p>
 
 <Box>
 

--- a/docs/src/componentDocs/UserMenu/markdown/UserMenuAPIDocs.mdx
+++ b/docs/src/componentDocs/UserMenu/markdown/UserMenuAPIDocs.mdx
@@ -84,7 +84,7 @@ You can override the default styles used by Brightlayer UI by:
 -   using the Global CSS Class in your main stylesheet
 
 {/* prettier-ignore */}
-<p>For more details on styling options check out our <a href={`https://github.com/brightlayer-ui/react-component-library/blob/${DOCS_BRANCH}/docs/src/shared/markdown/StyleOverridesGuide.md`}>Styling Guide</a>.</p>
+<p>For more details on styling options check out our <a href={`https://github.com/etn-ccis/blui-react-component-library/blob/${DOCS_BRANCH}/docs/src/shared/markdown/StyleOverridesGuide.md`}>Styling Guide</a>.</p>
 
 <Box>
 

--- a/docs/src/shared/FullCodeOnGithubButton.tsx
+++ b/docs/src/shared/FullCodeOnGithubButton.tsx
@@ -13,7 +13,7 @@ export const FullCodeOnGithub: React.FC<FullCodeOnGithubProps> = (props) => (
     <Button
         variant="outlined"
         target="_blank"
-        href={`https://github.com/brightlayer-ui/react-component-library/blob/${DOCS_BRANCH}/docs/src/${props.url}`}
+        href={`https://github.com/etn-ccis/blui-react-component-library/blob/${DOCS_BRANCH}/docs/src/${props.url}`}
         startIcon={<GitHubIcon />}
         sx={props.sx}
     >

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/brightlayer-ui/react-component-library"
+        "url": "https://github.com/etn-ccis/blui-react-component-library"
     },
     "keywords": [
         "react",
@@ -34,9 +34,9 @@
         "brightlayer-ui"
     ],
     "bugs": {
-        "url": "https://github.com/brightlayer-ui/react-component-library/issues"
+        "url": "https://github.com/etn-ccis/blui-react-component-library/issues"
     },
-    "homepage": "https://github.com/brightlayer-ui/react-component-library#readme",
+    "homepage": "https://github.com/etn-ccis/blui-react-component-library#readme",
     "directories": {
         "doc": "docs"
     },


### PR DESCRIPTION
Fixes #672 BLUI-3717

Changes:
Updated the old github repo links to new GHE repo links

To test: 
yarn start
Open github repo links
Should open GHE repo links