### PR TITLE
Updated emotion css license url

### DIFF
--- a/components/LICENSES.json
+++ b/components/LICENSES.json
@@ -8,7 +8,7 @@
     "@emotion/css@11.9.0": {
         "licenses": "MIT",
         "repository": "https://github.com/emotion-js/emotion/tree/main/packages/css",
-        "licenseUrl": "https://github.com/emotion-js/emotion/tree/main/packages/css/raw/master/LICENSE",
+        "licenseUrl": "https://github.com/emotion-js/emotion/raw/main/packages/css/LICENSE",
         "parents": "@brightlayer-ui/react-components"
     },
     "@seznam/compose-react-refs@1.0.6": {


### PR DESCRIPTION
Fixes #673 BLUI-3718

Changes - 
Updated license url of emotion css to https://github.com/emotion-js/emotion/raw/main/packages/css/LICENSE

To test- 
Open LICENSES.json in components directory
Click on licenseUrl to open in browser
Show open raw format of license