### PR TITLE
Stop activeItemBackgroundProp from being forwarded to the styled component

### DIFF
--- a/components/src/core/Drawer/DrawerRailItem/DrawerRailItem.tsx
+++ b/components/src/core/Drawer/DrawerRailItem/DrawerRailItem.tsx
@@ -163,6 +163,7 @@ const Root = styled(ButtonBase, {
 const ActiveItem = styled(Box, {
     name: 'drawer-rail-item',
     slot: 'active',
+    shouldForwardProp: (prop) => prop !== 'activeItemBackgroundColor',
 })<Pick<DrawerRailItemProps, 'activeItemBackgroundColor'>>(({ activeItemBackgroundColor, theme }) => {
     const fivePercentOpacityPrimary = color(
         theme.palette.mode === 'dark' ? theme.palette.primary.dark : theme.palette.primary.main


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

- Stop activeItemBackgroundProp from being forwarded to the styled component