### PR TITLE
Added disablePortal prop to Menu in usermenu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v6.3.0 (Unreleased)
+
+### Fixed
+
+-   Issue with `sx` prop in `<UserMenu>` component ([#437](https://github.com/etn-ccis/blui-react-component-library/issues/437)).
+
+
 ## v6.2.0 (January 24, 2023)
 
 ### Fixed

--- a/components/package.json
+++ b/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@brightlayer-ui/react-components",
-    "version": "6.2.0",
+    "version": "6.3.0",
     "description": "React components for Brightlayer UI applications",
     "scripts": {
         "test": "jest src",

--- a/components/src/core/UserMenu/UserMenu.tsx
+++ b/components/src/core/UserMenu/UserMenu.tsx
@@ -279,6 +279,7 @@ const UserMenuRender: React.ForwardRefRenderFunction<unknown, UserMenuProps> = (
             </DrawerBottomSheet>
         ) : (
             <Menu
+                disablePortal
                 open={Boolean(anchorEl)}
                 anchorEl={anchorEl}
                 onClose={closeMenu}


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes #437 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

-Added disablePortal prop to Menu in UserMenu

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)
<img width="1792" alt="Screenshot 2023-03-03 at 3 28 48 PM" src="https://user-images.githubusercontent.com/120575281/222690851-4b65fa22-1596-4673-af03-32fee7d718a0.png">

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- Checkout bug/sx-fix-user-menu branch in react showcase demo
- yarn build
- yarn start:showcase
- Go to Brightlayer UI Components -> Data Display
- Scroll Down to User Menu 
- Click on avatar in UserMenu within a Toolbar


<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
