### PR TITLE
Added disablePortal prop to DrawerBottomSheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
 
 -   Issue with `sx` prop in `<UserMenu>` component ([#437](https://github.com/etn-ccis/blui-react-component-library/issues/437)).
 
-
 ## v6.2.0 (January 24, 2023)
 
 ### Fixed

--- a/components/src/core/UserMenu/UserMenu.tsx
+++ b/components/src/core/UserMenu/UserMenu.tsx
@@ -272,6 +272,7 @@ const UserMenuRender: React.ForwardRefRenderFunction<unknown, UserMenuProps> = (
                 transitionDuration={theme.transitions.duration.short}
                 open={Boolean(anchorEl)}
                 onClose={closeMenu}
+                disablePortal
                 classes={{ paper: cx(defaultClasses.bottomSheet, classes.bottomSheet) }}
                 {...BottomSheetProps}
             >

--- a/docs/src/componentDocs/UserMenu/markdown/UserMenuAPIDocs.mdx
+++ b/docs/src/componentDocs/UserMenu/markdown/UserMenuAPIDocs.mdx
@@ -88,16 +88,16 @@ You can override the default styles used by Brightlayer UI by:
 
 <Box>
 
-| Name        | Global CSS Class            | Description                               |
-| :---------- | :-------------------------- | :---------------------------------------- |
-| root        | .BluiUserMenu-root          | Styles applied to the root element        |
-| bottomSheet | .BluiUserMenu-bottomsheet   | Styles applied to responsive bottom sheet |
-|             | .BluiUserMenu-avatarRoot    | Styles applied to the avatarRoot element  |
-|             | .BluiUserMenu-header        | Styles applied to the header element      |
-|             | .BluiUserMenu-headerRoot    | Styles applied to the headerRoot element  |
-|             | .BluiUserMenu-menuTitle     | Styles applied to the menuTitle element   |
-|             | .BluiUserMenu-navigation    | Styles applied to the navigation element  |
-|             | .BluiUserMenu-navGroups     | Styles applied to the navGroups element   |
+| Name        | Global CSS Class          | Description                               |
+| :---------- | :------------------------ | :---------------------------------------- |
+| root        | .BluiUserMenu-root        | Styles applied to the root element        |
+| bottomSheet | .BluiUserMenu-bottomsheet | Styles applied to responsive bottom sheet |
+|             | .BluiUserMenu-avatarRoot  | Styles applied to the avatarRoot element  |
+|             | .BluiUserMenu-header      | Styles applied to the header element      |
+|             | .BluiUserMenu-headerRoot  | Styles applied to the headerRoot element  |
+|             | .BluiUserMenu-menuTitle   | Styles applied to the menuTitle element   |
+|             | .BluiUserMenu-navigation  | Styles applied to the navigation element  |
+|             | .BluiUserMenu-navGroups   | Styles applied to the navGroups element   |
 
 </Box>
 

--- a/docs/src/componentDocs/UserMenu/markdown/UserMenuAPIDocs.mdx
+++ b/docs/src/componentDocs/UserMenu/markdown/UserMenuAPIDocs.mdx
@@ -101,8 +101,6 @@ You can override the default styles used by Brightlayer UI by:
 
 </Box>
 
-\* This element lives in a separate container and can't be styled via `sx` nesting rules.
-
 ### User Menu Groups Object
 
 The `menuGroups` prop of the `<UserMenu>` includes many properties from the [`<DrawerNavGroup>`](/components/drawer-nav-group/api-docs) array found within a [`<DrawerBody>`](/components/drawer-body/api-docs).

--- a/docs/src/componentDocs/UserMenu/markdown/UserMenuAPIDocs.mdx
+++ b/docs/src/componentDocs/UserMenu/markdown/UserMenuAPIDocs.mdx
@@ -91,7 +91,7 @@ You can override the default styles used by Brightlayer UI by:
 | Name        | Global CSS Class            | Description                               |
 | :---------- | :-------------------------- | :---------------------------------------- |
 | root        | .BluiUserMenu-root          | Styles applied to the root element        |
-| bottomSheet | .BluiUserMenu-bottomsheet\* | Styles applied to responsive bottom sheet |
+| bottomSheet | .BluiUserMenu-bottomsheet   | Styles applied to responsive bottom sheet |
 |             | .BluiUserMenu-avatarRoot    | Styles applied to the avatarRoot element  |
 |             | .BluiUserMenu-header        | Styles applied to the header element      |
 |             | .BluiUserMenu-headerRoot    | Styles applied to the headerRoot element  |


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes #437 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Added disablePortal in Usermenu BottomSheet

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

<img width="1341" alt="Screenshot 2023-03-10 at 8 13 48 PM" src="https://user-images.githubusercontent.com/120575281/224345293-9cb04073-1e27-4e58-87ee-d33aabfef080.png">

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:
- yarn build
- Checkout bug/sx-fix-user-menu branch in react showcase demo
- yarn build
- yarn start:showcase
- Go to Brightlayer UI Components -> Data Display
- Scroll Down to User Menu
- Enable responsiveness and select any mobile device
- Click on avatar in UserMenu within a Toolbar

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

- This PR is an extension to #719 to fix for mobile view
