### PR TITLE
Blui-3907 google analytics

### DIFF
--- a/docs/googleAnalytics/ga.dev.js
+++ b/docs/googleAnalytics/ga.dev.js
@@ -1,1 +1,1 @@
-export const gaID = '359685142';
+export const gaID = 'G-JY7JTQ87MB';

--- a/docs/googleAnalytics/ga.master.js
+++ b/docs/googleAnalytics/ga.master.js
@@ -1,1 +1,1 @@
-export const gaID = 'UA-139646200-3';
+export const gaID = 'G-Y2TXKYRFM0';

--- a/docs/package.json
+++ b/docs/package.json
@@ -76,6 +76,7 @@
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^14.2.0",
         "@types/color": "^3.0.3",
+        "@types/gtag.js": "^0.0.12",
         "@types/jest": "^27.5.2",
         "@types/lodash.debounce": "^4.0.7",
         "@types/mdx": "^2.0.2",

--- a/docs/package.json
+++ b/docs/package.json
@@ -60,7 +60,7 @@
         "react-app-polyfill": "^3.0.0",
         "react-app-rewired": "^2.2.1",
         "react-dom": "^18.2.0",
-        "react-ga": "^3.3.1",
+        "react-ga4": "^2.1.0",
         "react-redux": "^8.0.5",
         "react-router": "^6.8.0",
         "react-router-dom": "^6.8.0",

--- a/docs/public/index.html
+++ b/docs/public/index.html
@@ -1,47 +1,48 @@
 <!DOCTYPE html>
 <html lang="en">
-    <head>
-        <!-- Start Single Page Apps for GitHub Pages -->
-        <script type="text/javascript">
-            // Single Page Apps for GitHub Pages
-            // MIT License
-            // https://github.com/rafgraph/spa-github-pages
-            // This script checks to see if a redirect is present in the query string,
-            // converts it back into the correct url and adds it to the
-            // browser's history using window.history.replaceState(...),
-            // which won't cause the browser to attempt to load the new url.
-            // When the single page app is loaded further down in this file,
-            // the correct url will be waiting in the browser's history for
-            // the single page app to route accordingly.
-            (function (l) {
-                if (l.search[1] === '/') {
-                    var decoded = l.search
-                        .slice(1)
-                        .split('&')
-                        .map(function (s) {
-                            return s.replace(/~and~/g, '&');
-                        })
-                        .join('?');
-                    window.history.replaceState(null, null, l.pathname.slice(0, -1) + decoded + l.hash);
-                }
-            })(window.location);
-        </script>
-        <!-- End Single Page Apps for GitHub Pages -->
 
-        <meta charset="utf-8" />
-        <link rel="icon" href="%PUBLIC_URL%/favicon.png" />
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <meta name="theme-color" content="#000000" />
-        <meta name="description" content="Web site created using create-react-app" />
-        <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
-        <base href="%PUBLIC_URL%/" />
+<head>
+    <!-- Start Single Page Apps for GitHub Pages -->
+    <script type="text/javascript">
+        // Single Page Apps for GitHub Pages
+        // MIT License
+        // https://github.com/rafgraph/spa-github-pages
+        // This script checks to see if a redirect is present in the query string,
+        // converts it back into the correct url and adds it to the
+        // browser's history using window.history.replaceState(...),
+        // which won't cause the browser to attempt to load the new url.
+        // When the single page app is loaded further down in this file,
+        // the correct url will be waiting in the browser's history for
+        // the single page app to route accordingly.
+        (function (l) {
+            if (l.search[1] === '/') {
+                var decoded = l.search
+                    .slice(1)
+                    .split('&')
+                    .map(function (s) {
+                        return s.replace(/~and~/g, '&');
+                    })
+                    .join('?');
+                window.history.replaceState(null, null, l.pathname.slice(0, -1) + decoded + l.hash);
+            }
+        })(window.location);
+    </script>
+    <!-- End Single Page Apps for GitHub Pages -->
 
-        <!--
+    <meta charset="utf-8" />
+    <link rel="icon" href="%PUBLIC_URL%/favicon.png" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#000000" />
+    <meta name="description" content="Web site created using create-react-app" />
+    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+    <base href="%PUBLIC_URL%/" />
+
+    <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-        <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-        <!--
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.
       Only files inside the `public` folder can be referenced from the HTML.
@@ -49,17 +50,29 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-        <title>Brightlayer UI React Docs</title>
-    </head>
-    <body>
-        <noscript>You need to enable JavaScript to run this app.</noscript>
-        <div id="root"></div>
-        <!--
+    <title>Brightlayer UI React Docs</title>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-JY7JTQ87MB"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag() { dataLayer.push(arguments); }
+        gtag('js', new Date());
+
+        gtag('config', 'G-JY7JTQ87MB');
+    </script>
+</head>
+
+<body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+    <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.
       You can add webfonts, meta tags, or analytics to this file.
       The build step will place the bundled scripts into the <body> tag.
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
-    --></body>
+    -->
+</body>
+
 </html>

--- a/docs/public/index.html
+++ b/docs/public/index.html
@@ -51,6 +51,14 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>Brightlayer UI React Docs</title>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=%gaID%">
+    </script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag() { dataLayer.push(arguments); }
+        gtag('js', new Date());
+        gtag('config', '%gaID%', { send_page_view: false })
+    </script>
 </head>
 
 <body>

--- a/docs/public/index.html
+++ b/docs/public/index.html
@@ -2,15 +2,6 @@
 <html lang="en">
 
 <head>
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-JY7JTQ87MB"></script>
-    <script>
-        window.dataLayer = window.dataLayer || [];
-        function gtag() { dataLayer.push(arguments); }
-        gtag('js', new Date());
-
-        gtag('config', 'G-JY7JTQ87MB');
-    </script>
     <!-- Start Single Page Apps for GitHub Pages -->
     <script type="text/javascript">
         // Single Page Apps for GitHub Pages

--- a/docs/public/index.html
+++ b/docs/public/index.html
@@ -2,6 +2,15 @@
 <html lang="en">
 
 <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-JY7JTQ87MB"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag() { dataLayer.push(arguments); }
+        gtag('js', new Date());
+
+        gtag('config', 'G-JY7JTQ87MB');
+    </script>
     <!-- Start Single Page Apps for GitHub Pages -->
     <script type="text/javascript">
         // Single Page Apps for GitHub Pages
@@ -51,15 +60,6 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>Brightlayer UI React Docs</title>
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-JY7JTQ87MB"></script>
-    <script>
-        window.dataLayer = window.dataLayer || [];
-        function gtag() { dataLayer.push(arguments); }
-        gtag('js', new Date());
-
-        gtag('config', 'G-JY7JTQ87MB');
-    </script>
 </head>
 
 <body>

--- a/docs/src/index.tsx
+++ b/docs/src/index.tsx
@@ -30,7 +30,7 @@ import 'prismjs/plugins/line-numbers/prism-line-numbers.js';
 import 'prismjs/plugins/line-highlight/prism-line-highlight.js';
 
 // google analytics
-import ReactGA from 'react-ga';
+import ReactGA from 'react-ga4';
 import { gaID } from './ga.js';
 import { ScrollToTop } from './router/ScrollToTop';
 if (gaID) {

--- a/docs/src/router/GoogleAnalyticsWrapper.tsx
+++ b/docs/src/router/GoogleAnalyticsWrapper.tsx
@@ -6,9 +6,9 @@ export const GoogleAnalyticsWrapper: React.FC = () => {
     const location = useLocation();
     useEffect(() => {
         window.gtag('event', 'page_view', {
-            page_path: location.pathname + location.search + location.hash,
-            page_search: location.search,
-            page_hash: location.hash,
+            PAGE_PATH: location.pathname + location.search + location.hash,
+            PAGE_SEARCH: location.search,
+            PAGE_HASH: location.hash,
         });
     }, [location]);
     return null;

--- a/docs/src/router/GoogleAnalyticsWrapper.tsx
+++ b/docs/src/router/GoogleAnalyticsWrapper.tsx
@@ -5,7 +5,9 @@ import ReactGA from 'react-ga4';
 export const GoogleAnalyticsWrapper: React.FC = () => {
     const location = useLocation();
     useEffect(() => {
-        ReactGA.send(window.location.pathname + window.location.search);
+        ReactGA.send({
+            hitType: "window.location.pathname + window.location.search"
+        });
     }, [location.pathname, location.search]);
 
     return null;

--- a/docs/src/router/GoogleAnalyticsWrapper.tsx
+++ b/docs/src/router/GoogleAnalyticsWrapper.tsx
@@ -1,9 +1,15 @@
-import ReactGA from 'react-ga4';
+import React, { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+// import ReactGA from 'react-ga4';
 
 export const GoogleAnalyticsWrapper: React.FC = () => {
-    ReactGA.send({
-        hitType: 'pageview',
-    });
-
-    return null;
+    const location = useLocation();
+        useEffect(() => {
+            window.gtag("event", "page_view", {
+                page_path: location.pathname + location.search + location.hash,
+                page_search: location.search,
+                page_hash: location.hash,
+            });
+        }, [location]);
+        return null;
 };

--- a/docs/src/router/GoogleAnalyticsWrapper.tsx
+++ b/docs/src/router/GoogleAnalyticsWrapper.tsx
@@ -1,11 +1,11 @@
 import React, { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
-import ReactGA from 'react-ga';
+import ReactGA from 'react-ga4';
 
 export const GoogleAnalyticsWrapper: React.FC = () => {
     const location = useLocation();
     useEffect(() => {
-        ReactGA.pageview(window.location.pathname + window.location.search);
+        ReactGA.send(window.location.pathname + window.location.search);
     }, [location.pathname, location.search]);
 
     return null;

--- a/docs/src/router/GoogleAnalyticsWrapper.tsx
+++ b/docs/src/router/GoogleAnalyticsWrapper.tsx
@@ -1,14 +1,9 @@
-import React, { useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
 import ReactGA from 'react-ga4';
 
 export const GoogleAnalyticsWrapper: React.FC = () => {
-    const location = useLocation();
-    useEffect(() => {
-        ReactGA.send({
-            hitType: 'window.location.pathname + window.location.search',
-        });
-    }, [location.pathname, location.search]);
+    ReactGA.send({
+        hitType: 'pageview',
+    });
 
     return null;
 };

--- a/docs/src/router/GoogleAnalyticsWrapper.tsx
+++ b/docs/src/router/GoogleAnalyticsWrapper.tsx
@@ -4,12 +4,12 @@ import { useLocation } from 'react-router-dom';
 
 export const GoogleAnalyticsWrapper: React.FC = () => {
     const location = useLocation();
-        useEffect(() => {
-            window.gtag("event", "page_view", {
-                page_path: location.pathname + location.search + location.hash,
-                page_search: location.search,
-                page_hash: location.hash,
-            });
-        }, [location]);
-        return null;
+    useEffect(() => {
+        window.gtag('event', 'page_view', {
+            page_path: location.pathname + location.search + location.hash,
+            page_search: location.search,
+            page_hash: location.hash,
+        });
+    }, [location]);
+    return null;
 };

--- a/docs/src/router/GoogleAnalyticsWrapper.tsx
+++ b/docs/src/router/GoogleAnalyticsWrapper.tsx
@@ -6,7 +6,7 @@ export const GoogleAnalyticsWrapper: React.FC = () => {
     const location = useLocation();
     useEffect(() => {
         ReactGA.send({
-            hitType: 'window.location.pathname + window.location.search + pageview',
+            hitType: 'window.location.pathname + window.location.search',
         });
     }, [location.pathname, location.search]);
 

--- a/docs/src/router/GoogleAnalyticsWrapper.tsx
+++ b/docs/src/router/GoogleAnalyticsWrapper.tsx
@@ -6,7 +6,7 @@ export const GoogleAnalyticsWrapper: React.FC = () => {
     const location = useLocation();
     useEffect(() => {
         ReactGA.send({
-            hitType: 'window.location.pathname + window.location.search',
+            hitType: 'window.location.pathname + window.location.search + pageview',
         });
     }, [location.pathname, location.search]);
 

--- a/docs/src/router/GoogleAnalyticsWrapper.tsx
+++ b/docs/src/router/GoogleAnalyticsWrapper.tsx
@@ -6,7 +6,7 @@ export const GoogleAnalyticsWrapper: React.FC = () => {
     const location = useLocation();
     useEffect(() => {
         ReactGA.send({
-            hitType: "window.location.pathname + window.location.search"
+            hitType: 'window.location.pathname + window.location.search',
         });
     }, [location.pathname, location.search]);
 

--- a/docs/src/router/GoogleAnalyticsWrapper.tsx
+++ b/docs/src/router/GoogleAnalyticsWrapper.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
-// import ReactGA from 'react-ga4';
 
 export const GoogleAnalyticsWrapper: React.FC = () => {
     const location = useLocation();

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -2361,6 +2361,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/gtag.js@^0.0.12":
+  version "0.0.12"
+  resolved "https://registry.yarnpkg.com/@types/gtag.js/-/gtag.js-0.0.12.tgz#095122edca896689bdfcdd73b057e23064d23572"
+  integrity sha512-YQV9bUsemkzG81Ea295/nF/5GijnD2Af7QhEofh7xu+kvCN6RdodgNwwGWXB5GMI3NoyvQo0odNctoH/qLMIpg==
+
 "@types/hast@^2.0.0":
   version "2.3.4"
   resolved "https://registry.npmjs.org/@types/hast/-/hast-2.3.4.tgz"

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -9019,10 +9019,10 @@ react-error-overlay@^6.0.11:
   resolved "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz"
   integrity sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==
 
-react-ga@^3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/react-ga/-/react-ga-3.3.1.tgz#d8e1f4e05ec55ed6ff944dcb14b99011dfaf9504"
-  integrity sha512-4Vc0W5EvXAXUN/wWyxvsAKDLLgtJ3oLmhYYssx+YzphJpejtOst6cbIHCIyF50Fdxuf5DDKqRYny24yJ2y7GFQ==
+react-ga4@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/react-ga4/-/react-ga4-2.1.0.tgz#56601f59d95c08466ebd6edfbf8dede55c4678f9"
+  integrity sha512-ZKS7PGNFqqMd3PJ6+C2Jtz/o1iU9ggiy8Y8nUeksgVuvNISbmrQtJiZNvC/TjDsqD0QlU5Wkgs7i+w9+OjHhhQ==
 
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes BLUI-3907

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Use measurement ID as tracking ID for Dev/Master
- Update to use react-ga4 and gtag
- Add google tag manager script to index
- Change google analytics wrapper to include gtag

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)
![image](https://user-images.githubusercontent.com/119693939/228351424-23388e86-447b-49e9-87bb-86bea07d8425.png)


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- navigate to blui-react-docs--pr738-feature-blui-3907-ga-al07rtiy.web.app
- Login to GA analytics.google.com
- Select React Dev Docs (dev) GA4 from All website data list
- Select real time to verify yourself
- Select engagement > overview or event to see more details 
- Open dev tools on deployed site and search gaID (notice all pages are set to track)
- That's all I know .....
![image](https://user-images.githubusercontent.com/119693939/228352343-fb3c15a6-3d08-4b71-8401-e98bef5bca8e.png)


<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
