### PR TITLE
paddinY and marginY style changes when ripple and dense enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Fixed
 
 -   Issue with `sx` prop in `<UserMenu>` component ([#437](https://github.com/etn-ccis/blui-react-component-library/issues/437)).
--   Padding issue in `<InfoListItem>`, when `wrapTitle`, `wrapSubtitle` and `wrapInfo` props are enabled ([#712](https://github.com/etn-ccis/blui-react-component-library/issues/712)).
+-   Padding and margin issue in `<InfoListItem>`, when `wrapTitle`, `wrapSubtitle` and `wrapInfo` props are enabled ([#712](https://github.com/etn-ccis/blui-react-component-library/issues/712)).
 
 ## v6.2.0 (January 24, 2023)
 
@@ -271,11 +271,11 @@ Previous versions listed after this indicator refer to our deprecated `@pxblue` 
 
     /* New syntax */
     <DrawerNavGroup
-      	activeItem={'item1id'}
+        activeItem={'item1id'}
         items={[
             {
                 title: 'Item 1',
-              	itemID: 'item1id',
+                itemID: 'item1id',
             },
         ]}
     />

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v6.3.0 (Unreleased)
+## v6.3.0 (April 4, 2023)
 
 ### Removed
 

--- a/components/package.json
+++ b/components/package.json
@@ -38,7 +38,6 @@
         "eslint-plugin-jest-dom": "^4.0.3",
         "eslint-plugin-react": "^7.29.4",
         "eslint-plugin-testing-library": "^5.9.1",
-        "i": "^0.3.7",
         "jest": "^29.3.1",
         "jest-environment-jsdom": "^29.3.1",
         "npm": "^8.12.1",

--- a/components/src/core/InfoListItem/InfoListItemStyledComponents.tsx
+++ b/components/src/core/InfoListItem/InfoListItemStyledComponents.tsx
@@ -55,6 +55,8 @@ export const Root = styled(ListItem, {
         paddingTop: (isWrapEnabled() ? '0' : undefined),
         paddingBottom: (isWrapEnabled() ? '0' : undefined),
         '& .MuiListItemButton-root': {
+            minHeight: isWrapEnabled() ? getHeight() : 'initial',
+            height: !isWrapEnabled() ? getHeight() : 'auto',
             paddingTop: (isWrapEnabled() ? '0' : undefined),
             paddingBottom: (isWrapEnabled() ? '0' : undefined),
         },

--- a/components/src/core/InfoListItem/InfoListItemStyledComponents.tsx
+++ b/components/src/core/InfoListItem/InfoListItemStyledComponents.tsx
@@ -27,7 +27,7 @@ export const Root = styled(ListItem, {
     >
 >(({ onClick, backgroundColor, wrapSubtitle, wrapTitle, wrapInfo, dense, ripple, theme }) => {
     const isWrapEnabled = (): boolean => wrapSubtitle || wrapTitle || wrapInfo;
-    const getHeight = (): string => (dense ? `3.25rem` : `4.5rem`);
+    const getHeight = (): string => (dense ? `3.5rem` : `4.5rem`);
 
     let isCssColor = true;
     try {
@@ -52,8 +52,16 @@ export const Root = styled(ListItem, {
             outline: 'none',
         },
         padding: onClick && ripple ? 0 : undefined,
-        paddingTop: isWrapEnabled() ? 0 : 'auto',
-        paddingBottom: isWrapEnabled() ? 0 : 'auto',
+        paddingTop: (isWrapEnabled() ? '0' : undefined),
+        paddingBottom: (isWrapEnabled() ? '0' : undefined),
+        '& .MuiListItemButton-root': {
+            paddingTop: (isWrapEnabled() ? '0' : undefined),
+            paddingBottom: (isWrapEnabled() ? '0' : undefined),
+        },
+        '& .MuiListItemText-dense': {
+            marginTop: 0,
+            marginBottom: 0,
+        }
     };
 });
 


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes #712 .

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- PaddingY style changes when ripple is enabled
- MarginY style changes when dense is enabled
- Added fixed changes in changelog file

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

<img width="1440" alt="Screenshot 2023-03-31 at 4 48 59 PM" src="https://user-images.githubusercontent.com/48961073/229106970-e11dc0fc-6bd7-44ff-9462-e55e6890030e.png">
<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- yarn start:reactdev
- Select to InfoListItem component 
- Go to PlayGround 

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
