### PR TITLE
Use dense drawer nav items

### DIFF
--- a/components/yarn.lock
+++ b/components/yarn.lock
@@ -2989,11 +2989,6 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
-i@^0.3.7:
-  version "0.3.7"
-  resolved "https://registry.yarnpkg.com/i/-/i-0.3.7.tgz#2a7437a923d59c14b17243dc63a549af24d85799"
-  integrity sha512-FYz4wlXgkQwIPqhzC5TdNMLSE5+GS1IIDJZY/1ZiEPCT2S3COUVZeT5OW4BmW4r5LHLQuOosSwsvnroG9GR59Q==
-
 iconv-lite@0.6.3, iconv-lite@^0.6.2:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"

--- a/docs/src/pages/HomePage.tsx
+++ b/docs/src/pages/HomePage.tsx
@@ -8,7 +8,7 @@ import Typewriter from 'typewriter-effect';
 import { Github } from '@brightlayer-ui/icons-mui';
 import Mail from '@mui/icons-material/Mail';
 import { SharedAppBar } from '../layout';
-import { Theme } from '@mui/system';
+import { Theme } from '@mui/material';
 import { PADDING } from '../shared/constants';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { listOfAllBluiReactPackages } from '../__configuration__/listOfAllBluiReactPackages';

--- a/docs/src/router/drawer.tsx
+++ b/docs/src/router/drawer.tsx
@@ -9,7 +9,7 @@ import Chip from '@mui/material/Chip';
 import Typography from '@mui/material/Typography';
 import { DRAWER_WIDTH } from '../shared';
 import { React as ReactIcon } from '@brightlayer-ui/icons-mui';
-
+import { Theme } from '@mui/material';
 import { useAppDispatch, useAppSelector } from '../redux/hooks';
 import { RootState } from '../redux/store';
 import { closeDrawer, toggleDrawer } from '../redux/appState';
@@ -47,6 +47,18 @@ const convertNavItems = (
         });
     }
     return convertedItems;
+};
+
+const styles = {
+    denseDrawerItem: {
+        '& .BluiDrawerNavItem-root, & .BluiInfoListItem-root, & .MuiButtonBase-root.MuiListItemButton-root': {
+            height: (theme: Theme): string => theme.spacing(5),
+        },
+    },
+    navGroupTopDivider: {
+        borderTop: (theme: Theme): string => `1px solid ${theme.palette.divider}`,
+        mt: 1,
+    },
 };
 
 export const NavigationDrawer: React.FC = () => {
@@ -132,9 +144,9 @@ export const NavigationDrawer: React.FC = () => {
                 }
                 onClick={(): void => navigate('/')}
             />
-            <DrawerBody hidePadding>
+            <DrawerBody hidePadding sx={styles.denseDrawerItem}>
                 {pageDefinitions.map(
-                    (navGroup) =>
+                    (navGroup, navGroupIndex) =>
                         !navGroup.hidden && (
                             <DrawerNavGroup
                                 titleColor={theme.palette.primary.main}
@@ -147,6 +159,9 @@ export const NavigationDrawer: React.FC = () => {
                                     handleNavigate,
                                     dispatch
                                 )}
+                                titleDivider={false}
+                                // navGroupIndex 0 is a hidden group used by the landing page
+                                sx={navGroupIndex !== 1 ? styles.navGroupTopDivider : undefined}
                             />
                         )
                 )}
@@ -154,6 +169,8 @@ export const NavigationDrawer: React.FC = () => {
                     title="COMMUNITY"
                     titleColor={theme.palette.primary.main}
                     items={externalLinkDefinitions}
+                    titleDivider={false}
+                    sx={styles.navGroupTopDivider}
                 />
             </DrawerBody>
         </Drawer>


### PR DESCRIPTION
There is no JIRA ticket number associated with this effort.

## Changes proposed in this Pull Request:

- Changed drawer item height from 56px to 40px
- Moved the drawer nav group divider from bottom to top

## Screenshots / Screen Recording (if applicable)

Left: existing; right: proposed. The sreenshot is taken from my 16'' mac book (1792x1120 screen resolution)
<img width="692" alt="image" src="https://user-images.githubusercontent.com/8997218/229862242-75d8b146-64ee-40dc-9e97-10bb285de654.png">


