### PR TITLE
React dev doc dark theme

### DIFF
--- a/components/yarn.lock
+++ b/components/yarn.lock
@@ -2989,11 +2989,6 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
-i@^0.3.7:
-  version "0.3.7"
-  resolved "https://registry.yarnpkg.com/i/-/i-0.3.7.tgz#2a7437a923d59c14b17243dc63a549af24d85799"
-  integrity sha512-FYz4wlXgkQwIPqhzC5TdNMLSE5+GS1IIDJZY/1ZiEPCT2S3COUVZeT5OW4BmW4r5LHLQuOosSwsvnroG9GR59Q==
-
 iconv-lite@0.6.3, iconv-lite@^0.6.2:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"

--- a/docs/src/__configuration__/markdownMapping.tsx
+++ b/docs/src/__configuration__/markdownMapping.tsx
@@ -114,11 +114,11 @@ export const componentsMap = {
         return <InternalLink to={props.href} {...tProps} />;
     },
     p: (props: TypographyProps): JSX.Element => (
-        <Typography sx={{ lineHeight: '1.6', m: '15px auto' }} paragraph {...props} />
+        <Typography sx={{ lineHeight: '1.6', m: '15px auto' }} color={'text.primary'} paragraph {...props} />
     ),
     ul: (props: BoxProps): JSX.Element => <Box component={'ul'} sx={{ m: '15px auto', pl: '60px' }} {...props} />,
     li: (props: TypographyProps<'li'>): JSX.Element => (
-        <Typography component={'li'} className={'mdLi'} sx={{ m: '15px auto' }} {...props} />
+        <Typography component={'li'} className={'mdLi'} sx={{ m: '15px auto' }} color={'text.primary'} {...props} />
     ),
     blockquote: (props: TypographyProps<'blockquote'>): JSX.Element => (
         <Typography
@@ -188,6 +188,7 @@ export const componentsMap = {
                 overflow: 'auto',
                 boxSizing: 'border-box',
                 mb: 2,
+                color: 'text.primary',
 
                 table: {
                     textAlign: 'left',
@@ -216,13 +217,15 @@ export const componentsMap = {
                     borderBottom: 0,
                 },
                 thead: {
-                    backgroundColor: Colors.white[100],
+                    backgroundColor: (theme: Theme): string =>
+                        theme.palette.mode === 'light' ? Colors.white[100] : Colors.black[800],
                 },
                 'tbody tr:nth-of-type(odd)': {
-                    backgroundColor: Colors.white[50],
+                    backgroundColor: 'background.paper',
                 },
                 'tbody tr:nth-of-type(even)': {
-                    backgroundColor: Colors.white[100],
+                    backgroundColor: (theme: Theme): string =>
+                        theme.palette.mode === 'light' ? Colors.white[100] : Colors.black[800],
                 },
                 td: {
                     fontSize: '0.875rem',

--- a/docs/src/__types__/index.ts
+++ b/docs/src/__types__/index.ts
@@ -3,8 +3,13 @@ export type RangeDataTypes = {
     max: number;
     step: number;
 };
+export type SiteThemeType = 'light' | 'dark' | 'system';
 
-export type PayloadType = {
+export type AppStatePayloadType = {
+    siteTheme: SiteThemeType;
+};
+
+export type ComponentDocPayloadType = {
     propName: string;
     propValue: boolean | number | string | string[] | [];
     componentName: string;

--- a/docs/src/componentDocs/AppBar/markdown/AppBarAPIDocs.mdx
+++ b/docs/src/componentDocs/AppBar/markdown/AppBarAPIDocs.mdx
@@ -2,7 +2,7 @@ import Box from '@mui/material/Box';
 import AppBar from '../images/appBar.gif';
 import AppBarAnatomy1 from '../images/appBarAnatomy1.png';
 import AppBarAnatomy2 from '../images/appBarAnatomy2.png';
-import { DOCS_BRANCH } from '../../../shared/constants';
+import { ForMoreDetailsOnStylingOptions } from '../../../shared';
 
 # App Bar
 
@@ -98,8 +98,7 @@ You can override the default styles used by Brightlayer UI by:
 -   passing a `classes` prop with keys from the Name column below
 -   using the Global CSS Class in your main stylesheet
 
-{/* prettier-ignore */}
-<p>For more details on styling options check out our <a href={`https://github.com/etn-ccis/blui-react-component-library/blob/${DOCS_BRANCH}/docs/src/shared/markdown/StyleOverridesGuide.md`}>Styling Guide</a>.</p>
+<ForMoreDetailsOnStylingOptions />
 
 <Box>
 

--- a/docs/src/componentDocs/ChannelValue/markdown/ChannelValueAPIDocs.mdx
+++ b/docs/src/componentDocs/ChannelValue/markdown/ChannelValueAPIDocs.mdx
@@ -1,7 +1,7 @@
 import Box from '@mui/material/Box';
 import ChannelValueImage from '../images/channelValue.png';
 import ChannelValueAnatomyImage from '../images/channelValueAnatomy.png';
-import { DOCS_BRANCH } from '../../../shared/constants';
+import { ForMoreDetailsOnStylingOptions } from '../../../shared';
 
 # Channel Value
 
@@ -70,9 +70,7 @@ You can override the default styles used by Brightlayer UI by:
 -   passing a `classes` prop with keys from the Name column below
 -   using the Global CSS Class in your main stylesheet
 
-{/* prettier-ignore */}
-<p>For more details on styling options check out our <a href={`https://github.com/etn-ccis/blui-react-component-library/blob/${DOCS_BRANCH}/docs/src/shared/markdown/StyleOverridesGuide.md`}>Styling Guide</a>.</p>
-
+<ForMoreDetailsOnStylingOptions />
 <Box>
 
 | Name  | Global CSS Class        | Description                         |

--- a/docs/src/componentDocs/Drawer/markdown/DrawerAPIDocs.mdx
+++ b/docs/src/componentDocs/Drawer/markdown/DrawerAPIDocs.mdx
@@ -3,7 +3,7 @@ import Box from '@mui/material/Box';
 import Drawer from '../images/drawer.png';
 import DrawerAnatomy from '../images/drawerAnatomy.png';
 import SharedProps from '../../../shared/markdown/SharedProps.mdx';
-import { DOCS_BRANCH } from '../../../shared/constants';
+import { ForMoreDetailsOnStylingOptions } from '../../../shared';
 
 # Drawer
 
@@ -87,8 +87,7 @@ You can override the default styles used by Brightlayer UI by:
 -   passing a `classes` prop with keys from the Name column below
 -   using the Global CSS Class in your main stylesheet
 
-{/* prettier-ignore */}
-<p>For more details on styling options check out our <a href={`https://github.com/etn-ccis/blui-react-component-library/blob/${DOCS_BRANCH}/docs/src/shared/markdown/StyleOverridesGuide.md`}>Styling Guide</a>.</p>
+<ForMoreDetailsOnStylingOptions />
 
 <Box>
 

--- a/docs/src/componentDocs/DrawerFooter/markdown/DrawerFooterAPIDocs.mdx
+++ b/docs/src/componentDocs/DrawerFooter/markdown/DrawerFooterAPIDocs.mdx
@@ -1,5 +1,5 @@
 import Box from '@mui/material/Box';
-import { DOCS_BRANCH } from '../../../shared/constants';
+import { ForMoreDetailsOnStylingOptions } from '../../../shared';
 
 # Drawer Footer
 
@@ -27,8 +27,7 @@ You can override the default styles used by Brightlayer UI by:
 -   passing a `classes` prop with keys from the Name column below
 -   using the Global CSS Class in your main stylesheet
 
-{/* prettier-ignore */}
-<p>For more details on styling options check out our <a href={`https://github.com/etn-ccis/blui-react-component-library/blob/${DOCS_BRANCH}/docs/src/shared/markdown/StyleOverridesGuide.md`}>Styling Guide</a>.</p>
+<ForMoreDetailsOnStylingOptions />
 
 <Box  >
 

--- a/docs/src/componentDocs/DrawerHeader/markdown/DrawerHeaderAPIDocs.mdx
+++ b/docs/src/componentDocs/DrawerHeader/markdown/DrawerHeaderAPIDocs.mdx
@@ -1,6 +1,6 @@
 import Box from '@mui/material/Box';
 import DrawerHeaderAnatomy from '../images/drawerHeaderAnatomy.png';
-import { DOCS_BRANCH } from '../../../shared/constants';
+import { ForMoreDetailsOnStylingOptions } from '../../../shared';
 
 # Drawer Header
 
@@ -53,8 +53,7 @@ You can override the default styles used by Brightlayer UI by:
 -   passing a `classes` prop with keys from the Name column below
 -   using the Global CSS Class in your main stylesheet
 
-{/* prettier-ignore */}
-<p>For more details on styling options check out our <a href={`https://github.com/etn-ccis/blui-react-component-library/blob/${DOCS_BRANCH}/docs/src/shared/markdown/StyleOverridesGuide.md`}>Styling Guide</a>.</p>
+<ForMoreDetailsOnStylingOptions />
 
 <Box>
 

--- a/docs/src/componentDocs/DrawerLayout/markdown/DrawerLayoutAPIDocs.mdx
+++ b/docs/src/componentDocs/DrawerLayout/markdown/DrawerLayoutAPIDocs.mdx
@@ -1,7 +1,7 @@
 import Box from '@mui/material/Box';
 import DrawerLayoutImage from '../images/drawerLayout.png';
 import SharedProps from '../../../shared/markdown/SharedProps.mdx';
-import { DOCS_BRANCH } from '../../../shared/constants';
+import { ForMoreDetailsOnStylingOptions } from '../../../shared';
 
 # Drawer Layout
 
@@ -47,8 +47,7 @@ You can override the default styles used by Brightlayer UI by:
 -   passing a `classes` prop with keys from the Name column below
 -   using the Global CSS Class in your main stylesheet
 
-{/* prettier-ignore */}
-<p>For more details on styling options check out our <a href={`https://github.com/etn-ccis/blui-react-component-library/blob/${DOCS_BRANCH}/docs/src/shared/markdown/StyleOverridesGuide.md`}>Styling Guide</a>.</p>
+<ForMoreDetailsOnStylingOptions />
 
 <Box>
 

--- a/docs/src/componentDocs/DrawerNavGroup/markdown/DrawerNavGroupAPIDocs.mdx
+++ b/docs/src/componentDocs/DrawerNavGroup/markdown/DrawerNavGroupAPIDocs.mdx
@@ -1,7 +1,7 @@
 import Box from '@mui/material/Box';
 import DrawerNavGroupAnatomy from '../images/drawerNavGroupAnatomy.png';
 import SharedProps from '../../../shared/markdown/SharedProps.mdx';
-import { DOCS_BRANCH } from '../../../shared/constants';
+import { ForMoreDetailsOnStylingOptions } from '../../../shared';
 
 # Drawer Nav Group
 
@@ -53,8 +53,7 @@ You can override the default styles used by Brightlayer UI by:
 -   using the Global CSS Class in your main stylesheet
     the Global CSS Class in your main stylesheet
 
-{/* prettier-ignore */}
-<p>For more details on styling options check out our <a href={`https://github.com/etn-ccis/blui-react-component-library/blob/${DOCS_BRANCH}/docs/src/shared/markdown/StyleOverridesGuide.md`}>Styling Guide</a>.</p>
+<ForMoreDetailsOnStylingOptions />
 
 <Box>
 

--- a/docs/src/componentDocs/DrawerRailItem/markdown/DrawerRailItemAPIDocs.mdx
+++ b/docs/src/componentDocs/DrawerRailItem/markdown/DrawerRailItemAPIDocs.mdx
@@ -2,7 +2,7 @@ import Box from '@mui/material/Box';
 
 import RailAnatomy from '../images/railAnatomy.png';
 import SharedProps from '../../../shared/markdown/SharedProps.mdx';
-import { DOCS_BRANCH } from '../../../shared/constants';
+import { ForMoreDetailsOnStylingOptions } from '../../../shared';
 
 # Drawer Rail Item
 
@@ -54,8 +54,7 @@ You can override the default styles used by Brightlayer UI by:
 -   passing a `classes` prop with keys from the Name column below
 -   using the Global CSS Class in your main stylesheet
 
-{/* prettier-ignore */}
-<p>For more details on styling options check out our <a href={`https://github.com/etn-ccis/blui-react-component-library/blob/${DOCS_BRANCH}/docs/src/shared/markdown/StyleOverridesGuide.md`}>Styling Guide</a>.</p>
+<ForMoreDetailsOnStylingOptions />
 
 <Box>
 

--- a/docs/src/componentDocs/EmptyState/markdown/EmptyStateAPIDocs.mdx
+++ b/docs/src/componentDocs/EmptyState/markdown/EmptyStateAPIDocs.mdx
@@ -1,6 +1,6 @@
 import Box from '@mui/material/Box';
 import EmptyStateImage from '../images/emptyState.png';
-import { DOCS_BRANCH } from '../../../shared/constants';
+import { ForMoreDetailsOnStylingOptions } from '../../../shared';
 
 # Empty State
 
@@ -47,8 +47,7 @@ You can override the default styles used by Brightlayer UI by:
 -   passing a `classes` prop with keys from the Name column below
 -   using the Global CSS Class in your main stylesheet
 
-{/* prettier-ignore */}
-<p>For more details on styling options check out our <a href={`https://github.com/etn-ccis/blui-react-component-library/blob/${DOCS_BRANCH}/docs/src/shared/markdown/StyleOverridesGuide.md`}>Styling Guide</a>.</p>
+<ForMoreDetailsOnStylingOptions />
 
 <Box>
 

--- a/docs/src/componentDocs/Hero/markdown/HeroAPIDocs.mdx
+++ b/docs/src/componentDocs/Hero/markdown/HeroAPIDocs.mdx
@@ -1,7 +1,7 @@
 import Box from '@mui/material/Box';
 import HeroAnatomy from '../images/heroAnatomy.png';
 import Heroes from '../images/heroes.png';
-import { DOCS_BRANCH } from '../../../shared/constants';
+import { ForMoreDetailsOnStylingOptions } from '../../../shared';
 
 # Hero
 
@@ -72,8 +72,7 @@ You can override the default styles used by Brightlayer UI by:
 -   passing a `classes` prop with keys from the Name column below
 -   using the Global CSS Class in your main stylesheet
 
-{/* prettier-ignore */}
-<p>For more details on styling options check out our <a href={`https://github.com/etn-ccis/blui-react-component-library/blob/${DOCS_BRANCH}/docs/src/shared/markdown/StyleOverridesGuide.md`}>Styling Guide</a>.</p>
+<ForMoreDetailsOnStylingOptions />
 
 <Box>
 

--- a/docs/src/componentDocs/InfoListItem/markdown/InfoListItemAPIDocs.mdx
+++ b/docs/src/componentDocs/InfoListItem/markdown/InfoListItemAPIDocs.mdx
@@ -1,6 +1,6 @@
 import Box from '@mui/material/Box';
 import InfoListItem from '../images/infoListItem.png';
-import { DOCS_BRANCH } from '../../../shared/constants';
+import { ForMoreDetailsOnStylingOptions } from '../../../shared';
 
 # Info List Item
 
@@ -67,8 +67,7 @@ You can override the default styles used by Brightlayer UI by:
 -   passing a `classes` prop with keys from the Name column below
 -   using the Global CSS Class in your main stylesheet
 
-{/* prettier-ignore */}
-<p>For more details on styling options check out our <a href={`https://github.com/etn-ccis/blui-react-component-library/blob/${DOCS_BRANCH}/docs/src/shared/markdown/StyleOverridesGuide.md`}>Styling Guide</a>.</p>
+<ForMoreDetailsOnStylingOptions />
 
 <Box>
 

--- a/docs/src/componentDocs/ListItemTag/examples/ListItemTagUsingInfoListItem.tsx
+++ b/docs/src/componentDocs/ListItemTag/examples/ListItemTagUsingInfoListItem.tsx
@@ -7,7 +7,6 @@ const codeSnippet = `<InfoListItem
     icon={<BatteryChargingFull />}
     title="Info List Item"
     subtitle="with a ListItemTag component to the right"
-    backgroundColor="white"
     iconColor="text.primary"
     rightComponent={
         <Stack spacing={2} direction={'row'}>

--- a/docs/src/componentDocs/ListItemTag/examples/ListItemTagUsingInfoListItemExample.tsx
+++ b/docs/src/componentDocs/ListItemTag/examples/ListItemTagUsingInfoListItemExample.tsx
@@ -8,11 +8,10 @@ import { ExampleShowcase } from '../../../shared';
 export const ListItemTagUsingInfoListItemExample = (): JSX.Element => (
     <ExampleShowcase sx={{ display: 'flex', justifyContent: 'center' }}>
         <InfoListItem
-            sx={{ width: 'auto' }}
+            sx={{ width: 'auto', backgroundColor: 'background.paper' }}
             icon={<BatteryChargingFull />}
             title="Info List Item"
             subtitle="with a ListItemTag component to the right"
-            backgroundColor="white"
             iconColor="text.primary"
             rightComponent={
                 <Stack spacing={2} direction={'row'}>

--- a/docs/src/componentDocs/ListItemTag/markdown/ListItemTagAPIDocs.mdx
+++ b/docs/src/componentDocs/ListItemTag/markdown/ListItemTagAPIDocs.mdx
@@ -1,6 +1,6 @@
 import Box from '@mui/material/Box';
 import ListItemTag from '../images/listItemTag.png';
-import { DOCS_BRANCH } from '../../../shared/constants';
+import { ForMoreDetailsOnStylingOptions } from '../../../shared';
 
 # List Item Tag
 
@@ -43,8 +43,7 @@ You can override the default styles used by Brightlayer UI by:
 -   passing a `classes` prop with keys from the Name column below
 -   using the Global CSS Class in your main stylesheet
 
-{/* prettier-ignore */}
-<p>For more details on styling options check out our <a href={`https://github.com/etn-ccis/blui-react-component-library/blob/${DOCS_BRANCH}/docs/src/shared/markdown/StyleOverridesGuide.md`}>Styling Guide</a>.</p>
+<ForMoreDetailsOnStylingOptions />
 
 <Box>
 | Name | Global CSS Class      | Description                        |

--- a/docs/src/componentDocs/ScoreCard/markdown/ScoreCardAPIDocs.mdx
+++ b/docs/src/componentDocs/ScoreCard/markdown/ScoreCardAPIDocs.mdx
@@ -1,7 +1,7 @@
 import Box from '@mui/material/Box';
 import ScoreCard from '../images/scoreCard.png';
 import ScoreCardAlt from '../images/scoreCard_alt.png';
-import { DOCS_BRANCH } from '../../../shared/constants';
+import { ForMoreDetailsOnStylingOptions } from '../../../shared';
 
 # Score Card
 
@@ -66,8 +66,7 @@ You can override the default styles used by Brightlayer UI by:
 -   passing a `classes` prop with keys from the Name column below
 -   using the Global CSS Class in your main stylesheet
 
-{/* prettier-ignore */}
-<p>For more details on styling options check out our <a href={`https://github.com/etn-ccis/blui-react-component-library/blob/${DOCS_BRANCH}/docs/src/shared/markdown/StyleOverridesGuide.md`}>Styling Guide</a>.</p>
+<ForMoreDetailsOnStylingOptions />
 
 <Box>
 

--- a/docs/src/componentDocs/Spacer/markdown/SpacerAPIDocs.mdx
+++ b/docs/src/componentDocs/Spacer/markdown/SpacerAPIDocs.mdx
@@ -1,6 +1,6 @@
 import Box from '@mui/material/Box';
 import Spacer from '../images/spacer.png';
-import { DOCS_BRANCH } from '../../../shared/constants';
+import { ForMoreDetailsOnStylingOptions } from '../../../shared';
 
 # Spacer
 
@@ -46,8 +46,7 @@ You can override the default styles used by Brightlayer UI by:
 -   passing a `classes` prop with keys from the Name column below
 -   using the Global CSS Class in your main stylesheet
 
-{/* prettier-ignore */}
-<p>For more details on styling options check out our <a href={`https://github.com/etn-ccis/blui-react-component-library/blob/${DOCS_BRANCH}/docs/src/shared/markdown/StyleOverridesGuide.md`}>Styling Guide</a>.</p>
+<ForMoreDetailsOnStylingOptions />
 
 <Box>
 

--- a/docs/src/componentDocs/ThreeLiner/markdown/ThreeLinerAPIDocs.mdx
+++ b/docs/src/componentDocs/ThreeLiner/markdown/ThreeLinerAPIDocs.mdx
@@ -1,5 +1,5 @@
 import Box from '@mui/material/Box';
-import { DOCS_BRANCH } from '../../../shared/constants';
+import { ForMoreDetailsOnStylingOptions } from '../../../shared';
 
 # Three Liner
 
@@ -27,8 +27,7 @@ You can override the default styles used by Brightlayer UI by:
 -   passing a `classes` prop with keys from the Name column below
 -   using the Global CSS Class in your main stylesheet
 
-{/* prettier-ignore */}
-<p>For more details on styling options check out our <a href={`https://github.com/etn-ccis/blui-react-component-library/blob/${DOCS_BRANCH}/docs/src/shared/markdown/StyleOverridesGuide.md`}>Styling Guide</a>.</p>
+<ForMoreDetailsOnStylingOptions />
 
 <Box>
 

--- a/docs/src/componentDocs/ToolbarMenu/markdown/ToolbarMenuAPIDocs.mdx
+++ b/docs/src/componentDocs/ToolbarMenu/markdown/ToolbarMenuAPIDocs.mdx
@@ -1,6 +1,6 @@
 import Box from '@mui/material/Box';
 import ToolbarMenuAnatomy from '../images/ToolbarMenuAnatomy.png';
-import { DOCS_BRANCH } from '../../../shared/constants';
+import { ForMoreDetailsOnStylingOptions } from '../../../shared';
 
 # Toolbar Menu
 
@@ -48,8 +48,7 @@ You can override the default styles used by Brightlayer UI by:
 -   passing a `classes` prop with keys from the Name column below
 -   using the Global CSS Class in your main stylesheet
 
-{/* prettier-ignore */}
-<p>For more details on styling options check out our <a href={`https://github.com/etn-ccis/blui-react-component-library/blob/${DOCS_BRANCH}/docs/src/shared/markdown/StyleOverridesGuide.md`}>Styling Guide</a>.</p>
+<ForMoreDetailsOnStylingOptions />
 
 <Box>
 

--- a/docs/src/componentDocs/ToolbarMenu/playground/PreviewComponent.tsx
+++ b/docs/src/componentDocs/ToolbarMenu/playground/PreviewComponent.tsx
@@ -17,18 +17,31 @@ export const PreviewComponent = (): JSX.Element => {
     const generateCodeSnippet = (): string => {
         const jsx = `<ToolbarMenu
     ${toggleDefaultProp('icon', toolbarMenuProps.icon)}
-    label={"${toolbarMenuProps.label}"}
-    menuGroups={
-        {
-            items: [{ title: "Menu Item 1", onClick: (): void => {
-                console.log("clicked 1");
-            } }, { title: "Menu Item 2", onClick: (): void => {
-                console.log("clicked 2");
-            } }, { title: "Menu Item 3", onClick: (): void => {
-                console.log("clicked 3");
-            } }],
-        },
-    ]} />`;
+    label={'${toolbarMenuProps.label}'}
+    menuGroups={{
+        items: [
+            {
+                title: 'Menu Item 1',
+                onClick: (): void => {
+                    console.log('clicked 1');
+                },
+            },
+            {
+                title: 'Menu Item 2',
+                onClick: (): void => {
+                    console.log('clicked 2');
+                },
+            },
+            {
+                title: 'Menu Item 3',
+                onClick: (): void => {
+                    console.log('clicked 3');
+                },
+            },
+        ],
+    }}
+/>`;
+
         return removeEmptyLines(jsx);
     };
     const menuGroups = [

--- a/docs/src/componentDocs/UserMenu/markdown/UserMenuAPIDocs.mdx
+++ b/docs/src/componentDocs/UserMenu/markdown/UserMenuAPIDocs.mdx
@@ -2,7 +2,7 @@ import Box from '@mui/material/Box';
 import UserMenuAvatar from '../images/userMenuAvatar.png';
 import UserMenuOpened from '../images/userMenuOpened.png';
 import UserMenuOpenedMobile from '../images/userMenuOpenedMobile.png';
-import { DOCS_BRANCH } from '../../../shared/constants';
+import { ForMoreDetailsOnStylingOptions } from '../../../shared';
 
 # User Menu
 
@@ -83,8 +83,7 @@ You can override the default styles used by Brightlayer UI by:
 -   passing a `classes` prop with keys from the Name column below
 -   using the Global CSS Class in your main stylesheet
 
-{/* prettier-ignore */}
-<p>For more details on styling options check out our <a href={`https://github.com/etn-ccis/blui-react-component-library/blob/${DOCS_BRANCH}/docs/src/shared/markdown/StyleOverridesGuide.md`}>Styling Guide</a>.</p>
+<ForMoreDetailsOnStylingOptions />
 
 <Box>
 

--- a/docs/src/index.css
+++ b/docs/src/index.css
@@ -18,7 +18,6 @@ body,
 
 a,
 a:not(.MuiTab-root):visited {
-    color: #007bc1;
     font-weight: 400;
 }
 

--- a/docs/src/index.tsx
+++ b/docs/src/index.tsx
@@ -13,13 +13,15 @@ import { BrowserRouter } from 'react-router-dom';
 import { createTheme, ThemeProvider, StyledEngineProvider } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
 import * as BLUIThemes from '@brightlayer-ui/react-themes';
+import useMediaQuery from '@mui/material/useMediaQuery';
 import '@brightlayer-ui/react-themes/open-sans';
 import '@fontsource/roboto';
 import '@fontsource/roboto-mono';
 import { App } from './App';
 import reportWebVitals from './reportWebVitals';
 import './index.css';
-import { store } from './redux/store';
+import { store, RootState } from './redux/store';
+import { useAppSelector } from './redux/hooks';
 import { MDXProvider } from '@mdx-js/react';
 import { componentsMap } from './__configuration__/markdownMapping';
 import { GoogleAnalyticsWrapper } from './router/GoogleAnalyticsWrapper';
@@ -45,20 +47,38 @@ if (!container) throw new Error('Root Element was not found in the DOM');
 const root = ReactDOMClient.createRoot(container);
 const basename = process.env.PUBLIC_URL || '/';
 
+const ThemedApp = (): JSX.Element => {
+    const siteTheme = useAppSelector((state: RootState) => state.appState.siteTheme);
+    const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
+    let theme = BLUIThemes.blue;
+    if (siteTheme === 'dark' || (siteTheme === 'system' && prefersDarkMode)) {
+        theme = BLUIThemes.blueDark;
+    }
+
+    // force an update
+    const MemoThemedApp = React.useCallback(
+        () => (
+            <ThemeProvider theme={createTheme(theme)}>
+                <MDXProvider components={componentsMap as any}>
+                    <App />
+                </MDXProvider>
+            </ThemeProvider>
+        ),
+        [siteTheme, prefersDarkMode]
+    );
+    return <MemoThemedApp />;
+};
+
 root.render(
     <StyledEngineProvider injectFirst>
-        <ThemeProvider theme={createTheme(BLUIThemes.blue)}>
-            <BrowserRouter basename={basename}>
-                <ScrollToTop />
-                <GoogleAnalyticsWrapper />
-                <CssBaseline />
-                <Provider store={store}>
-                    <MDXProvider components={componentsMap as any}>
-                        <App />
-                    </MDXProvider>
-                </Provider>
-            </BrowserRouter>
-        </ThemeProvider>
+        <BrowserRouter basename={basename}>
+            <ScrollToTop />
+            <GoogleAnalyticsWrapper />
+            <CssBaseline />
+            <Provider store={store}>
+                <ThemedApp />
+            </Provider>
+        </BrowserRouter>
     </StyledEngineProvider>
 );
 

--- a/docs/src/layout/SharedAppBar.tsx
+++ b/docs/src/layout/SharedAppBar.tsx
@@ -1,16 +1,43 @@
 import React from 'react';
+
+// components
 import AppBar from '@mui/material/AppBar';
 import Toolbar from '@mui/material/Toolbar';
 import IconButton from '@mui/material/IconButton';
-import Menu from '@mui/icons-material/Menu';
+import MenuIcon from '@mui/icons-material/Menu';
 import useMediaQuery from '@mui/material/useMediaQuery';
-import { toggleDrawer } from '../redux/appState';
-import { useAppDispatch } from '../redux/hooks';
-import { useTheme } from '@mui/material/styles';
+import Radio from '@mui/material/Radio';
+import RadioGroup from '@mui/material/RadioGroup';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import FormControl from '@mui/material/FormControl';
 import Typography from '@mui/material/Typography';
+import { Spacer } from '@brightlayer-ui/react-components';
+import { Settings } from '@mui/icons-material';
+import Menu from '@mui/material/Menu';
+import Divider from '@mui/material/Divider';
+import Box from '@mui/material/Box';
+
+// hooks
+import { toggleDrawer, changeSiteTheme } from '../redux/appState';
+import { useAppDispatch, useAppSelector } from '../redux/hooks';
+import { useTheme } from '@mui/material/styles';
+import { RootState } from '../redux/store';
+import { SiteThemeType } from '../__types__';
 
 export type SharedAppBarProps = {
     title: string;
+};
+
+const styles = {
+    formControl: {
+        px: 2,
+        pb: 1,
+    },
+    caption: {
+        px: 2,
+        pt: 1,
+        width: 280,
+    },
 };
 
 export const SharedAppBar: React.FC<SharedAppBarProps> = (props): JSX.Element => {
@@ -18,27 +45,101 @@ export const SharedAppBar: React.FC<SharedAppBarProps> = (props): JSX.Element =>
     const theme = useTheme();
     const lgUp = useMediaQuery(theme.breakpoints.up('lg'));
     const dispatch = useAppDispatch();
+    const [themeSelectorAnchorEl, setThemeSelectorAnchorEl] = React.useState<null | HTMLElement>(null);
+    const siteTheme = useAppSelector((state: RootState) => state.appState.siteTheme);
+
+    const onClickThemeSelectorItem = React.useCallback(
+        (option: SiteThemeType): void => {
+            dispatch(changeSiteTheme({ siteTheme: option }));
+            setThemeSelectorAnchorEl(null);
+        },
+        [dispatch]
+    );
+
+    const ThemeSelector = React.useCallback(
+        () => (
+            <Menu
+                open={Boolean(themeSelectorAnchorEl)}
+                anchorEl={themeSelectorAnchorEl}
+                onClose={(): void => {
+                    setThemeSelectorAnchorEl(null);
+                }}
+            >
+                <FormControl sx={styles.formControl}>
+                    <RadioGroup
+                        aria-labelledby="demo-radio-buttons-group-label"
+                        defaultValue={siteTheme}
+                        name="radio-buttons-group"
+                    >
+                        <FormControlLabel
+                            value="light"
+                            control={<Radio />}
+                            label="Light Theme"
+                            onClick={(): void => onClickThemeSelectorItem('light')}
+                        />
+                        <FormControlLabel
+                            value="dark"
+                            control={<Radio />}
+                            label="Dark Theme"
+                            onClick={(): void => onClickThemeSelectorItem('dark')}
+                        />
+                        <FormControlLabel
+                            value="system"
+                            control={<Radio />}
+                            label="System Default"
+                            onClick={(): void => onClickThemeSelectorItem('system')}
+                        />
+                    </RadioGroup>
+                </FormControl>
+                <Divider />
+                <Box sx={styles.caption}>
+                    <Typography variant={'caption'} color={'text.secondary'}>
+                        This website is themed using our React theme package. Learn more{' '}
+                        <a href={'/themes/overview'} style={{ color: 'inherit' }}>
+                            here
+                        </a>
+                        .
+                    </Typography>
+                </Box>
+            </Menu>
+        ),
+        [siteTheme, themeSelectorAnchorEl]
+    );
 
     return (
-        <AppBar position={'sticky'} elevation={0} sx={{ zIndex: 10000 }}>
-            <Toolbar sx={{ px: 2 }}>
-                {!lgUp && (
+        <>
+            <AppBar position={'sticky'} elevation={0} sx={{ zIndex: 'appBar' }}>
+                <Toolbar sx={{ px: 2 }}>
+                    {!lgUp && (
+                        <IconButton
+                            color={'inherit'}
+                            onClick={(): void => {
+                                dispatch(toggleDrawer());
+                            }}
+                            edge={'start'}
+                            sx={{ mr: 2.5 }}
+                            size="large"
+                        >
+                            <MenuIcon />
+                        </IconButton>
+                    )}
+                    <Typography variant={'h6'} color={'inherit'}>
+                        {title}
+                    </Typography>
+                    <Spacer />
                     <IconButton
                         color={'inherit'}
-                        onClick={(): void => {
-                            dispatch(toggleDrawer());
+                        size={'large'}
+                        edge={'end'}
+                        onClick={(e): void => {
+                            setThemeSelectorAnchorEl(e.currentTarget);
                         }}
-                        edge={'start'}
-                        sx={{ mr: 2.5 }}
-                        size="large"
                     >
-                        <Menu />
+                        <Settings />
                     </IconButton>
-                )}
-                <Typography variant={'h6'} color={'inherit'}>
-                    {title}
-                </Typography>
-            </Toolbar>
-        </AppBar>
+                </Toolbar>
+            </AppBar>
+            <ThemeSelector />
+        </>
     );
 };

--- a/docs/src/pages/HomePage.tsx
+++ b/docs/src/pages/HomePage.tsx
@@ -49,9 +49,6 @@ const styles = {
         outlined: {
             color: 'primary.contrastText',
             borderColor: 'primary.contrastText',
-            '&:not(.MuiTab-root):visited': {
-                color: 'primary.contrastText',
-            },
         },
     },
 };

--- a/docs/src/pages/componentPreviewPage.tsx
+++ b/docs/src/pages/componentPreviewPage.tsx
@@ -1,54 +1,17 @@
 import React, { HTMLAttributes } from 'react';
-import AppBar from '@mui/material/AppBar';
-import IconButton from '@mui/material/IconButton';
-import Toolbar from '@mui/material/Toolbar';
-import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
-import Menu from '@mui/icons-material/Menu';
+import { SharedAppBar } from '../layout';
 import { ComponentPreviewTabs } from '../shared';
-import { toggleDrawer } from '../redux/appState';
-import { useAppDispatch } from '../redux/hooks';
-import { useTheme } from '@mui/material/styles';
-import useMediaQuery from '@mui/material/useMediaQuery';
 
 export type ComponentPreviewPageProps = HTMLAttributes<HTMLDivElement> & {
     title: string;
 };
 export const ComponentPreviewPage: React.FC<ComponentPreviewPageProps> = (props): JSX.Element => {
     const { title } = props;
-    const dispatch = useAppDispatch();
-    const theme = useTheme();
-    const lgUp = useMediaQuery(theme.breakpoints.up('lg'));
 
     return (
         <Box style={{ display: 'flex', flexDirection: 'column' }}>
-            <AppBar
-                position={'sticky'}
-                elevation={0}
-                sx={{
-                    backgroundColor: theme.palette.background.paper,
-                    color: 'text.primary',
-                }}
-            >
-                <Toolbar sx={{ px: 2 }}>
-                    {lgUp ? null : (
-                        <IconButton
-                            color={'inherit'}
-                            onClick={(): void => {
-                                dispatch(toggleDrawer());
-                            }}
-                            edge={'start'}
-                            sx={{ mr: 3 }}
-                            size="large"
-                        >
-                            <Menu />
-                        </IconButton>
-                    )}
-                    <Typography variant={'h6'} color={'inherit'}>
-                        {title}
-                    </Typography>
-                </Toolbar>
-            </AppBar>
+            <SharedAppBar title={title} />
             <ComponentPreviewTabs />
         </Box>
     );

--- a/docs/src/redux/appState.tsx
+++ b/docs/src/redux/appState.tsx
@@ -1,11 +1,16 @@
-import { createSlice } from '@reduxjs/toolkit';
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { AppStatePayloadType, SiteThemeType } from '../__types__';
 
 type AppState = {
     drawerOpen: boolean;
+    siteTheme: SiteThemeType;
 };
+
+const siteTheme = localStorage.getItem('site-theme') as null | SiteThemeType;
 
 const initialState: AppState = {
     drawerOpen: false,
+    siteTheme: siteTheme === null ? 'light' : siteTheme,
 };
 
 export const appStateSlice = createSlice({
@@ -20,9 +25,16 @@ export const appStateSlice = createSlice({
             ...state,
             drawerOpen: !state.drawerOpen,
         }),
+        changeSiteTheme: (state, action: PayloadAction<AppStatePayloadType>) => {
+            localStorage.setItem('site-theme', action.payload.siteTheme);
+            return {
+                ...state,
+                siteTheme: action.payload.siteTheme,
+            };
+        },
     },
 });
 
-export const { closeDrawer, toggleDrawer } = appStateSlice.actions;
+export const { closeDrawer, toggleDrawer, changeSiteTheme } = appStateSlice.actions;
 
 export default appStateSlice.reducer;

--- a/docs/src/redux/componentsPropsState.tsx
+++ b/docs/src/redux/componentsPropsState.tsx
@@ -18,7 +18,7 @@ import threeLinerConfig from '../componentDocs/ThreeLiner/playground/ThreeLinerC
 import toolbarMenuConfig from '../componentDocs/ToolbarMenu/playground/ToolbarMenuConfig';
 import userMenuConfig from '../componentDocs/UserMenu/playground/UserMenuConfig';
 import { getComponentState } from '../shared/utilities';
-import { PayloadType, ComponentType } from '../__types__';
+import { ComponentDocPayloadType, ComponentType } from '../__types__';
 
 type ComponentState = {
     appBarComponent: ComponentType;
@@ -67,28 +67,28 @@ export const componentPropsStateSlice = createSlice({
     initialState: initialState,
     reducers: {
         resetProps: () => initialState,
-        updateProp: (state, action: PayloadAction<PayloadType>) => {
+        updateProp: (state, action: PayloadAction<ComponentDocPayloadType>) => {
             const newArray = getComponentState(action.payload.componentName, state);
             const updatedKnob = newArray?.props?.filter((prop) => prop.propName === action.payload.propName);
             if (updatedKnob) {
                 updatedKnob[0].inputValue = action.payload.propValue;
             }
         },
-        updateSharedProp: (state, action: PayloadAction<PayloadType>) => {
+        updateSharedProp: (state, action: PayloadAction<ComponentDocPayloadType>) => {
             const newArray = getComponentState(action.payload.componentName, state);
             const updatedKnob = newArray?.sharedProps?.filter((prop) => prop.propName === action.payload.propName);
             if (updatedKnob) {
                 updatedKnob[0].inputValue = action.payload.propValue;
             }
         },
-        updateOtherProp: (state, action: PayloadAction<PayloadType>) => {
+        updateOtherProp: (state, action: PayloadAction<ComponentDocPayloadType>) => {
             const newArray = getComponentState(action.payload.componentName, state);
             const updatedKnob = newArray?.otherProps?.filter((prop) => prop.propName === action.payload.propName);
             if (updatedKnob) {
                 updatedKnob[0].inputValue = action.payload.propValue;
             }
         },
-        updateOtherComponentProp: (state, action: PayloadAction<PayloadType>) => {
+        updateOtherComponentProp: (state, action: PayloadAction<ComponentDocPayloadType>) => {
             const newArray = getComponentState(action.payload.componentName, state);
             const updatedKnob = newArray?.otherComponentProps?.childComponentProps?.filter(
                 (prop) => prop.propName === action.payload.propName
@@ -97,7 +97,7 @@ export const componentPropsStateSlice = createSlice({
                 updatedKnob[0].inputValue = action.payload.propValue;
             }
         },
-        updateComponentProp: (state, action: PayloadAction<PayloadType>) => {
+        updateComponentProp: (state, action: PayloadAction<ComponentDocPayloadType>) => {
             const newArray = getComponentState(action.payload.componentName, state);
             const updatedKnob = newArray?.props?.filter((prop) => prop.propName === action.payload.propName);
             if (updatedKnob) {

--- a/docs/src/router/drawer.tsx
+++ b/docs/src/router/drawer.tsx
@@ -115,7 +115,7 @@ export const NavigationDrawer: React.FC = () => {
                             </Typography>
                             <Chip
                                 sx={{
-                                    color: 'primary.main',
+                                    color: theme.palette.mode === 'light' ? 'primary.main' : 'primary.dark',
                                     backgroundColor: 'white',
                                 }}
                                 icon={<ReactIcon color={'primary'} />}

--- a/docs/src/router/drawer.tsx
+++ b/docs/src/router/drawer.tsx
@@ -4,9 +4,9 @@ import useMediaQuery from '@mui/material/useMediaQuery';
 import { useNavigate, useLocation } from 'react-router';
 import { Drawer, DrawerBody, DrawerHeader, DrawerNavGroup, NavItem } from '@brightlayer-ui/react-components';
 import { externalLinkDefinitions, pageDefinitions, RouteConfig } from '../__configuration__/navigationMenu/navigation';
-import Box from '@mui/material/Box';
 import Chip from '@mui/material/Chip';
 import Typography from '@mui/material/Typography';
+import Stack from '@mui/material/Stack';
 import { DRAWER_WIDTH } from '../shared';
 import { React as ReactIcon } from '@brightlayer-ui/icons-mui';
 
@@ -96,20 +96,15 @@ export const NavigationDrawer: React.FC = () => {
                     },
                 }}
                 titleContent={
-                    <div
-                        style={{
-                            display: 'flex',
+                    <Stack
+                        justifyContent={'center'}
+                        sx={{
                             zIndex: 1,
-                            padding: '0 16px',
-                            alignItems: 'flex-start',
-                            width: '100%',
-                            height: '100%',
-                            flexDirection: 'column',
-                            justifyContent: 'center',
+                            px: 2,
                         }}
                     >
                         <Typography variant="subtitle1">Brightlayer User Interface</Typography>
-                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                        <Stack direction={'row'} alignItems={'center'} gap={1}>
                             <Typography variant={'body2'} paragraph={false}>
                                 Developer Docs
                             </Typography>
@@ -127,8 +122,8 @@ export const NavigationDrawer: React.FC = () => {
                                 variant={'filled'}
                                 size={'small'}
                             />
-                        </Box>
-                    </div>
+                        </Stack>
+                    </Stack>
                 }
                 onClick={(): void => navigate('/')}
             />

--- a/docs/src/shared/ExampleShowcase.tsx
+++ b/docs/src/shared/ExampleShowcase.tsx
@@ -9,7 +9,18 @@ export type ExampleShowcaseProps = BoxProps & {
 
 export const ExampleShowcase = React.forwardRef(
     (props: ExampleShowcaseProps, ref): JSX.Element => (
-        <Box ref={ref} sx={{ my: 2, backgroundColor: colors.white[600], p: 4, borderRadius: '4px', ...props.sx }}>
+        <Box
+            ref={ref}
+            sx={{
+                my: 2,
+                backgroundColor: (theme: Theme) =>
+                    theme.palette.mode === 'light' ? colors.white[600] : colors.darkBlack[300],
+                p: 4,
+                color: 'text.primary',
+                borderRadius: '4px',
+                ...props.sx,
+            }}
+        >
             {props.children}
         </Box>
     )

--- a/docs/src/shared/PlaygroundDrawer.tsx
+++ b/docs/src/shared/PlaygroundDrawer.tsx
@@ -206,6 +206,7 @@ const PlaygroundDrawer = (props: DrawerProps): JSX.Element => {
                 '&:before': {
                     display: 'none',
                 },
+                backgroundImage: 'unset',
             }}
         >
             <AccordionSummary expandIcon={<ExpandMoreIcon sx={{ color: 'primary.main' }} />}>
@@ -260,6 +261,7 @@ const PlaygroundDrawer = (props: DrawerProps): JSX.Element => {
                                 fontFamily: '"Roboto Mono", monspace',
                             },
                             zIndex: theme.zIndex.appBar - 1,
+                            backgroundColor: 'background.paper',
                         },
                     }}
                     anchor={'right'}

--- a/docs/src/shared/PlaygroundDrawer.tsx
+++ b/docs/src/shared/PlaygroundDrawer.tsx
@@ -107,6 +107,11 @@ const PlaygroundDrawer = (props: DrawerProps): JSX.Element => {
                 onChange={(event): void =>
                     handleChange(prop.propName, String(event.target.value), componentName, index)
                 }
+                MenuProps={{
+                    BackdropProps: {
+                        sx: { display: 'none' },
+                    },
+                }}
             >
                 {Array.isArray(prop.options)
                     ? prop.options?.map(

--- a/docs/src/shared/PreviewComponentWithCode.tsx
+++ b/docs/src/shared/PreviewComponentWithCode.tsx
@@ -25,7 +25,8 @@ const PreviewComponentWithCode: React.FC<PreviewComponentProps> = (props): JSX.E
                     display: 'flex',
                     justifyContent: 'center',
                     alignItems: 'center',
-                    bgcolor: Colors.white[200],
+                    bgcolor: 'background.default',
+                    color: 'text.primary',
                 }}
             >
                 {previewContent}

--- a/docs/src/shared/PreviewComponentWithCode.tsx
+++ b/docs/src/shared/PreviewComponentWithCode.tsx
@@ -27,6 +27,7 @@ const PreviewComponentWithCode: React.FC<PreviewComponentProps> = (props): JSX.E
                     alignItems: 'center',
                     bgcolor: 'background.default',
                     color: 'text.primary',
+                    overflow: 'hidden',
                 }}
             >
                 {previewContent}

--- a/docs/src/shared/TabPanel.tsx
+++ b/docs/src/shared/TabPanel.tsx
@@ -20,7 +20,7 @@ export const TabPanel = (props: TabPanelProps): JSX.Element => {
             {...other}
         >
             {value === index && (
-                <Box sx={{ backgroundColor: '#FFFFFF' }}>
+                <Box sx={{ backgroundColor: 'background.paper' }}>
                     <Typography component={'div'}>{children}</Typography>
                 </Box>
             )}

--- a/docs/src/shared/components/InfoCard/InfoCard.tsx
+++ b/docs/src/shared/components/InfoCard/InfoCard.tsx
@@ -97,7 +97,9 @@ export const InfoCard: React.FC<InfoCardProps> = (props): JSX.Element => {
                     </div>
                 </Box>
             )}
-            <Typography variant={'h6'}>{props.title}</Typography>
+            <Typography variant={'h6'} color={'text.primary'}>
+                {props.title}
+            </Typography>
             <Typography variant={'body2'} style={{ color: theme.palette.text.secondary, marginTop: theme.spacing(1) }}>
                 {props.description}
             </Typography>

--- a/docs/src/shared/components/InfoCard/InfoCard.tsx
+++ b/docs/src/shared/components/InfoCard/InfoCard.tsx
@@ -1,5 +1,5 @@
 import React, { MouseEvent } from 'react';
-import { Typography, useTheme, SxProps, Box } from '@mui/material';
+import { Typography, SxProps, Box } from '@mui/material';
 
 const getTopPaddingForAspectRatio = (ratio: AspectRatio | undefined): string => {
     switch (ratio) {
@@ -51,7 +51,6 @@ const styles: { [key: string]: SxProps } = {
 
 export const InfoCard: React.FC<InfoCardProps> = (props): JSX.Element => {
     const { background = {} } = props;
-    const theme = useTheme();
 
     return (
         <Box
@@ -100,7 +99,7 @@ export const InfoCard: React.FC<InfoCardProps> = (props): JSX.Element => {
             <Typography variant={'h6'} color={'text.primary'}>
                 {props.title}
             </Typography>
-            <Typography variant={'body2'} style={{ color: theme.palette.text.secondary, marginTop: theme.spacing(1) }}>
+            <Typography variant={'body2'} sx={{ color: 'text.secondary', mt: 1 }}>
                 {props.description}
             </Typography>
             <div>{props.descriptionContent}</div>

--- a/docs/src/shared/index.tsx
+++ b/docs/src/shared/index.tsx
@@ -12,3 +12,4 @@ export * from './CodeBlockActionButtonRow';
 export * from './ExampleShowcase';
 export * from './CallToActionButton';
 export * from './theme';
+export * from './markdown';

--- a/docs/src/shared/markdown/ForMoreDetailsOnStylingOptions.tsx
+++ b/docs/src/shared/markdown/ForMoreDetailsOnStylingOptions.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { DOCS_BRANCH } from '../constants';
+import Box from '@mui/material/Box';
+import { useTheme } from '@mui/material';
+
+// This blurb gets strange styling when used directly in markdown files
+export const ForMoreDetailsOnStylingOptions = (): JSX.Element => {
+    const theme = useTheme();
+
+    return (
+        <Box sx={{ color: 'text.primary', mb: 2 }}>
+            For more details on styling options check out our{' '}
+            <a
+                href={`https://github.com/etn-ccis/blui-react-component-library/blob/${DOCS_BRANCH}/docs/src/shared/markdown/StyleOverridesGuide.md`}
+                style={{ color: theme.palette.primary.main }}
+            >
+                Styling Guide
+            </a>
+            .
+        </Box>
+    );
+};

--- a/docs/src/shared/markdown/index.tsx
+++ b/docs/src/shared/markdown/index.tsx
@@ -1,0 +1,1 @@
+export * from './ForMoreDetailsOnStylingOptions';


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

There is no JIRA issue associated with this.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

## Changes proposed in this Pull Request:

- Added a theme toggler
- Ensured that most of the UI work in the dark theme

<!-- Include screenshots if they will help illustrate the changes in this PR -->

## Screenshots / Screen Recording (if applicable)

![image](https://user-images.githubusercontent.com/8997218/229940739-1faa73ab-3215-4242-b305-a2ddefa2d480.png)

## To Test

- [Toggle light/dark theme in Chrome's developer tool](https://stackoverflow.com/questions/57606960/how-can-i-emulate-prefers-color-scheme-media-query-in-chrome)
- Known issue: when switching between light and dark theme, the underline in a tab always gets misaligned, like this: 
![image](https://user-images.githubusercontent.com/8997218/229941692-fc09e6a5-3043-4bca-8fee-c9f878646985.png)
- Known issue: https://github.com/etn-ccis/blui-react-themes/issues/66
