### PR TITLE
Added a condition for no playground to Tabs in docs

### DIFF
--- a/docs/src/shared/ComponentPreviewTabs.tsx
+++ b/docs/src/shared/ComponentPreviewTabs.tsx
@@ -83,7 +83,7 @@ export const ComponentPreviewTabs = (): JSX.Element => {
     return (
         <>
             <Tabs
-                value={value}
+                value={!hidePlaygroundTab ? value : 0}
                 onChange={handleChange}
                 aria-label="component docs tabs"
                 centered

--- a/docs/src/shared/ComponentPreviewTabs.tsx
+++ b/docs/src/shared/ComponentPreviewTabs.tsx
@@ -83,7 +83,7 @@ export const ComponentPreviewTabs = (): JSX.Element => {
     return (
         <>
             <Tabs
-                value={!hidePlaygroundTab ? value : 0}
+                value={hidePlaygroundTab && value === 2 ? 0 : value}
                 onChange={handleChange}
                 aria-label="component docs tabs"
                 centered


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes #690 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:
- Added condition to check no playground while passing value to Tabs
- 
<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

https://user-images.githubusercontent.com/120575281/230294648-c74087f7-f4fc-45d6-b4d5-991320472e15.mov

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:
- Go to drawer component playground with dev tools open
- Click on draw layout
- warning displayed in console
- shared/ComponentPreviewTabs

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

- This issue only exists on local
