### PR TITLE
update gtag to use react app gaid

### DIFF
--- a/docs/public/index.html
+++ b/docs/public/index.html
@@ -57,7 +57,7 @@
         window.dataLayer = window.dataLayer || [];
         function gtag() { dataLayer.push(arguments); }
         gtag('js', new Date());
-        gtag('config', '%gaID%', { send_page_view: false })
+        gtag('config', '%REACT_APP_GAID%', { send_page_view: false })
     </script>
 </head>
 

--- a/docs/public/index.html
+++ b/docs/public/index.html
@@ -51,7 +51,7 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>Brightlayer UI React Docs</title>
-    <script async src="https://www.googletagmanager.com/gtag/js?id=%gaID%">
+    <script async src="https://www.googletagmanager.com/gtag/js?id=%REACT_APP_GAID%">
     </script>
     <script>
         window.dataLayer = window.dataLayer || [];


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

With the current changes in the PR, I see no page views coming in running of the firebase deployment but I do see "users" increment on count and would need to actually test this config under a dev deployment to see what's going on. If anyone has ideas on this let me know

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- update to use %REACT_APP_GAID% in index
-
-

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

-

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

-

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
