### PR TITLE
remove tag manager & run with react ga4 only

### DIFF
--- a/docs/public/index.html
+++ b/docs/public/index.html
@@ -51,14 +51,6 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>Brightlayer UI React Docs</title>
-    <script async src="https://www.googletagmanager.com/gtag/js?id=%REACT_APP_GAID%">
-    </script>
-    <script>
-        window.dataLayer = window.dataLayer || [];
-        function gtag() { dataLayer.push(arguments); }
-        gtag('js', new Date());
-        gtag('config', '%REACT_APP_GAID%', { send_page_view: false });
-    </script>
 </head>
 
 <body>

--- a/docs/src/router/GoogleAnalyticsWrapper.tsx
+++ b/docs/src/router/GoogleAnalyticsWrapper.tsx
@@ -1,14 +1,12 @@
 import React, { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
+import ReactGA from 'react-ga4';
 
 export const GoogleAnalyticsWrapper: React.FC = () => {
     const location = useLocation();
     useEffect(() => {
-        window.gtag('event', 'page_view', {
-            PAGE_PATH: location.pathname + location.search + location.hash,
-            PAGE_SEARCH: location.search,
-            PAGE_HASH: location.hash,
-        });
-    }, [location]);
+        ReactGA.send(window.location.pathname + window.location.search);
+    }, [location.pathname, location.search]);
+
     return null;
 };


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Test run using only react-ga4 and drop google tag manager

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Remove google tag manager script from index
- Switch to use react ga4
-

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

-

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

-

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
