### PR TITLE
Mention React Auth Workflow in dev doc

### DIFF
--- a/docs/src/__configuration__/navigationMenu/navigation.tsx
+++ b/docs/src/__configuration__/navigationMenu/navigation.tsx
@@ -71,9 +71,6 @@ import { ListItemTag } from '@brightlayer-ui/react-components';
 // Site markdown docs
 import * as markdownDocs from '../../markdownDocs/';
 
-// import ExampleConfigRender from '../../components/Playground/exampleConfigRender';
-// import ExampleConfig2Render from '../../components/Playground/exampleConfig2Render';
-
 export type RouteConfig = Omit<RouteProps, 'children'> & {
     title: string;
     icon?: JSX.Element;
@@ -83,22 +80,6 @@ export type RouteConfig = Omit<RouteProps, 'children'> & {
 };
 
 export const pageDefinitions: RouteConfig[] = [
-    // {
-    //     title: 'Test Playground',
-    //     path: '/test-playground/',
-    //     pages: [
-    //         {
-    //             title: 'Channel Value',
-    //             path: 'channel-value',
-    //             element: <ExampleConfigRender />,
-    //         },
-    //         {
-    //             title: 'Score Card',
-    //             path: 'score-card',
-    //             element: <ExampleConfig2Render />,
-    //         },
-    //     ],
-    // },
     {
         title: 'Home',
         path: '/',

--- a/docs/src/__configuration__/navigationMenu/navigation.tsx
+++ b/docs/src/__configuration__/navigationMenu/navigation.tsx
@@ -569,6 +569,18 @@ export const pageDefinitions: RouteConfig[] = [
             },
         ],
     },
+    {
+        title: 'Workflows',
+        path: '/workflows/',
+        element: <Outlet />,
+        pages: [
+            {
+                title: 'User Authentication',
+                path: 'user-auth',
+                element: <MarkdownPage title={'User Authentication Workflow'} markdown={markdownDocs.UserAuth} />,
+            },
+        ],
+    },
 ];
 
 const openInNewTab = (url = '#'): any => {
@@ -601,7 +613,6 @@ export const externalLinkDefinitions = [
     {
         title: 'Roadmap',
         itemID: 'Roadmap',
-        divider: true,
         rightComponent: <OpenInNew color="disabled" />,
         onClick: (): void => openInNewTab('https://brightlayer-ui.github.io/roadmap'),
     },

--- a/docs/src/markdownDocs/index.tsx
+++ b/docs/src/markdownDocs/index.tsx
@@ -10,4 +10,7 @@ import ThemeCustomization from './themes/customization.mdx';
 // Components
 import AllComponents from './allComponents.mdx';
 
-export { Environment, React, ThemesOverview, ThemesUsage, ThemeCustomization, AllComponents };
+// Workflows
+import UserAuth from './workflows/user-auth.mdx';
+
+export { Environment, React, ThemesOverview, ThemesUsage, ThemeCustomization, AllComponents, UserAuth };

--- a/docs/src/markdownDocs/workflows/user-auth.mdx
+++ b/docs/src/markdownDocs/workflows/user-auth.mdx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+# React User Authentication Workflow
+
+The React User Authentication Workflow package, `@brightlayer-ui/react-auth-workflow`, provides a consistent and comprehensive UI implementation of authentication-related capabilities for use in Eaton web applications built with React.
+
+The package is intended to provide a standard, out-of-the-box experience for capabilities such as:
+
+-   Login
+-   Forgot / Reset Password
+-   Change Password
+-   Contact Support
+-   Self Registration
+-   Invitation-based Registration
+
+This package is flexible, allowing you to use the Login and Registration flows independently or in combination (or simply use individual screen components), while also providing many opportunities to customize the flows if needed for your particular application.
+
+[Read more about this package](https://github.com/etn-ccis/blui-react-workflows/tree/master/login-workflow) on GitHub.

--- a/docs/src/router/drawer.tsx
+++ b/docs/src/router/drawer.tsx
@@ -54,6 +54,7 @@ const styles = {
         '& .BluiDrawerNavItem-root, & .BluiInfoListItem-root, & .MuiButtonBase-root.MuiListItemButton-root': {
             height: (theme: Theme): string => theme.spacing(5),
         },
+        paddingBottom: (theme: Theme): string => theme.spacing(2),
     },
     navGroupTopDivider: {
         borderTop: (theme: Theme): string => `1px solid ${theme.palette.divider}`,


### PR DESCRIPTION
Added a section in the Dev Doc to direct the traffic to GitHub readmes

![image](https://github.com/etn-ccis/blui-react-component-library/assets/8997218/c18c511a-8970-4fb4-9dd3-6e5003ab0bbd)

## To Test
* `yarn && yarn start:reactdev`
* The new page is located at http://localhost:3000/workflows/user-auth