### PR TITLE
Add nav item props to shared props

### DIFF
--- a/docs/src/shared/markdown/SharedProps.mdx
+++ b/docs/src/shared/markdown/SharedProps.mdx
@@ -1,10 +1,10 @@
 import Box from '@mui/material/Box';
 
-## Shared Props
+## Drawer Shared Props
 
 The following props can be set at any level in the drawer hierarchy ([`<Drawer>`](/components/drawer/api-docs), [`<DrawerBody>`](/components/drawer-body/api-docs), [`<DrawerNavGroup>`](/components/drawer-nav-group/api-docs), [`<DrawerNavItem>`](/components/drawer-nav-item/api-docs), or [`<DrawerRailItem>`](/components/drawer-rail-item/api-docs)). If they are set on a parent, they will be used for all children. For more customization, you can set these props on individual children and they will override any value set on the parent.
 
-<Box id='shared-props'>
+<Box id='drawer-shared-props'>
 
 | Name                      | Description                                               | Type      | Required | Default                     |
 | :------------------------ | :-------------------------------------------------------- | :-------- | :------- | :-------------------------- |
@@ -16,5 +16,23 @@ The following props can be set at any level in the drawer hierarchy ([`<Drawer>`
 | itemFontColor             | The color used for the item text                          | `string`  | no       | varies for light/dark theme |
 | itemIconColor             | The color used for the icon                               | `string`  | no       | varies for light/dark theme |
 | ripple                    | Whether to apply material ripple effect to items on click | `boolean` | no       | true                        |
+
+</Box>
+
+## Drawer Nav Item Props
+
+<Box id='drawer-nav-item-props'>
+
+| Name                          | Description                                                                    | Type                    | Required | Default                          |
+| :---------------------------- | :----------------------------------------------------------------------------- | :---------------------- | :------- | :------------------------------- |
+| activeItemBackgroundShape     | Shape of the active item background                                            | `'round'` \| `'square'` | no       | `square`                         |
+| chevron                       | Whether to have chevrons for all menu items                                    | `boolean`               | no       | `false`                          |
+| chevronColor                  | Color override for the chevron icon                                            | `string`                | no       | `varies for light/dark theme`    |
+| collapseIcon                  | Icon used to collapse nav group                                                | `JSX.Element`           | no       | `expandIcon rotated 180 degrees` |
+| expandIcon                    | Icon used to expand nav group                                                  | `JSX.Element`           | no       |                                  |
+| hidePadding                   | Whether to hide the paddings reserved for menu item icons                      | `boolean`               | no       | `false`                          |
+| disableActiveItemParentStyles | Disables the semi-bold style on parent elements in the selected item hierarchy | `boolean`               | no       | `false`                          |
+| nestedBackgroundColor         | Background color for a nested section of menu items                            | `string`                | no       | `varies for light/dark theme`    |
+| nestedDivider                 | Whether to apply a dividing line under nested navigation items                 | `boolean`               | no       | `false`                          |
 
 </Box>


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes https://github.com/etn-ccis/blui-react-component-library/issues/776.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Added drawer nav item props (right now they are in the shared props file and will move)
-
-

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

-

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

-

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
