### PR TITLE
fix new line code snippet in playground

### DIFF
--- a/docs/src/componentDocs/DrawerFooter/playground/PlaygroundPage.tsx
+++ b/docs/src/componentDocs/DrawerFooter/playground/PlaygroundPage.tsx
@@ -102,7 +102,9 @@ const generateSnippet: CodeSnippetFunction = (data) =>
     ${getPropsToString(getPropsMapping(data, inputConfig), { join: '\n\t', skip: ['open'] })}
 >
     <Box sx={{ p: 2 }}>Footer Content Here</Box>
-</DrawerFooter>`.replace(/^\s*$(?:\r\n?|\n)/gm, '');
+</DrawerFooter>`
+        .replace(/^\s*$(?:\r\n?|\n)/gm, '')
+        .replace(/^<DrawerFooter(\s)+\n>/, '<DrawerFooter>');
 
 export const DrawerFooterPlaygroundComponent = (): JSX.Element => (
     <Box

--- a/docs/src/componentDocs/DrawerSubheader/playground/PlaygroundPage.tsx
+++ b/docs/src/componentDocs/DrawerSubheader/playground/PlaygroundPage.tsx
@@ -94,7 +94,9 @@ const generateSnippet: CodeSnippetFunction = (data) =>
     ${getPropsToString(getPropsMapping(data, inputConfig), { join: '\n\t', skip: ['open'] })}
 >
     <Box sx={{ p: 2 }}>Subheader Content Here</Box>
-</DrawerSubheader>`.replace(/^\s*$(?:\r\n?|\n)/gm, '');
+</DrawerSubheader>`
+        .replace(/^\s*$(?:\r\n?|\n)/gm, '')
+        .replace(/^<DrawerSubheader(\s)+\n>/, '<DrawerSubheader>');
 
 export const DrawerSubheaderPlaygroundComponent = (): JSX.Element => (
     <Box


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes https://github.com/etn-ccis/blui-react-component-library/issues/830.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- replace empty new line
-
-

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

- old
![image](https://github.com/etn-ccis/blui-react-component-library/assets/119693939/1b5903e9-fdfa-44fa-8dda-b4b52831a4fe)
- new
![image](https://github.com/etn-ccis/blui-react-component-library/assets/119693939/2cd6e58c-f247-4255-9615-b45a16d00b09)


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- https://blui-react-docs--pr844-fix-blui-5258-remove-f29bz5ku.web.app/components/drawer-subheader/playground
- and toggle props
<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
