### PR TITLE
Use router icon in empty state playground

### DIFF
--- a/docs/src/componentDocs/EmptyState/playground/PlaygroundPage.tsx
+++ b/docs/src/componentDocs/EmptyState/playground/PlaygroundPage.tsx
@@ -22,7 +22,7 @@ const inputConfig: InputConfig = [
         typeLabel: 'ReactNode',
         description: 'The primary icon',
         initialValue: '<Devices />',
-        options: ['<Devices />', '<Router />', '<SensorsOff />'],
+        options: ['<Devices />', '<RouterIcon />', '<SensorsOff />'],
         required: true,
         category: 'Required Props',
     },


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes https://github.com/etn-ccis/blui-react-component-library/issues/831.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Update icon name
-
-

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

-

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- https://blui-react-docs--pr845-fix-blui-5259-missin-fyqdgqcw.web.app/components/empty-state/playground
- and toggle icons

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
