### PR TITLE
update playground replace tabs with spaces

### DIFF
--- a/docs/src/componentDocs/AppBar/playground/PlaygroundPage.tsx
+++ b/docs/src/componentDocs/AppBar/playground/PlaygroundPage.tsx
@@ -148,6 +148,7 @@ const generateSnippet: CodeSnippetFunction = (data) =>
     </Toolbar>
 </AppBar>`
         .replace(/^\s*$(?:\r\n?|\n)/gm, '')
+        .replace(/(?:^|)( {4}|\t)/gm, '    ')
         .replace(/^<AppBar(\s)+\n>/, '<AppBar>');
 
 export const AppBarPlaygroundComponent = (): JSX.Element => (

--- a/docs/src/componentDocs/ChannelValue/playground/PlaygroundPage.tsx
+++ b/docs/src/componentDocs/ChannelValue/playground/PlaygroundPage.tsx
@@ -133,7 +133,9 @@ const generateSnippet: CodeSnippetFunction = (data) =>
               })}}`
             : ''
     }
-/>`.replace(/^\s*$(?:\r\n?|\n)/gm, '');
+/>`
+        .replace(/^\s*$(?:\r\n?|\n)/gm, '')
+        .replace(/(?:^|)( {4}|\t)/gm, '    ');
 
 export const ChannelValuePlaygroundComponent = (): JSX.Element => (
     <Box

--- a/docs/src/componentDocs/Drawer/playground/PlaygroundPage.tsx
+++ b/docs/src/componentDocs/Drawer/playground/PlaygroundPage.tsx
@@ -303,7 +303,9 @@ const generateSnippet: CodeSnippetFunction = (data) =>
     <DrawerBody>
         <DrawerNavGroup {...navGroupProps} />
     </DrawerBody>
-</Drawer>`.replace(/^\s*$(?:\r\n?|\n)/gm, '');
+</Drawer>`
+        .replace(/^\s*$(?:\r\n?|\n)/gm, '')
+        .replace(/(?:^|)( {4}|\t)/gm, '    ');
 
 export const DrawerPlaygroundComponent = (): JSX.Element => (
     <Box

--- a/docs/src/componentDocs/DrawerFooter/playground/PlaygroundPage.tsx
+++ b/docs/src/componentDocs/DrawerFooter/playground/PlaygroundPage.tsx
@@ -102,7 +102,9 @@ const generateSnippet: CodeSnippetFunction = (data) =>
     ${getPropsToString(getPropsMapping(data, inputConfig), { join: '\n\t', skip: ['open'] })}
 >
     <Box sx={{ p: 2 }}>Footer Content Here</Box>
-</DrawerFooter>`.replace(/^\s*$(?:\r\n?|\n)/gm, '');
+</DrawerFooter>`
+        .replace(/^\s*$(?:\r\n?|\n)/gm, '')
+        .replace(/(?:^|)( {4}|\t)/gm, '    ');
 
 export const DrawerFooterPlaygroundComponent = (): JSX.Element => (
     <Box

--- a/docs/src/componentDocs/DrawerHeader/playground/PlaygroundPage.tsx
+++ b/docs/src/componentDocs/DrawerHeader/playground/PlaygroundPage.tsx
@@ -145,7 +145,9 @@ const generateSnippet: CodeSnippetFunction = (data) =>
     ${getPropsToString(getPropsMapping(data, inputConfig), { join: '\n\t', skip: ['icon', 'backgroundImage'] })}
     ${data.icon && data.icon !== 'undefined' ? `icon={${getIconSnippetWithProps(data.icon as string)}}` : ''}
     ${data.backgroundImage !== 'undefined' ? `backgroundImage={'../images/${data.backgroundImage as string}.png'}` : ''}
-/>`.replace(/^\s*$(?:\r\n?|\n)/gm, '');
+/>`
+        .replace(/^\s*$(?:\r\n?|\n)/gm, '')
+        .replace(/(?:^|)( {4}|\t)/gm, '    ');
 
 export const DrawerHeaderPlaygroundComponent = (): JSX.Element => (
     <Box

--- a/docs/src/componentDocs/DrawerNavGroup/playground/PlaygroundPage.tsx
+++ b/docs/src/componentDocs/DrawerNavGroup/playground/PlaygroundPage.tsx
@@ -139,7 +139,9 @@ const generateSnippet: CodeSnippetFunction = (data) =>
     ${data.collapseIcon !== 'undefined' ? `collapseIcon={${getIconSnippetWithProps(data.collapseIcon as string)}}` : ''}
     ${data.expandIcon !== 'undefined' ? `expandIcon={${getIconSnippetWithProps(data.expandIcon as string)}}` : ''}
     items={navGroupItems}
-/>`.replace(/^\s*$(?:\r\n?|\n)/gm, '');
+/>`
+        .replace(/^\s*$(?:\r\n?|\n)/gm, '')
+        .replace(/(?:^|)( {4}|\t)/gm, '    ');
 
 export const DrawerNavGroupPlaygroundComponent = (): JSX.Element => (
     <Box

--- a/docs/src/componentDocs/DrawerNavItem/playground/PlaygroundPage.tsx
+++ b/docs/src/componentDocs/DrawerNavItem/playground/PlaygroundPage.tsx
@@ -104,7 +104,9 @@ const generateSnippet: CodeSnippetFunction = (data) =>
     ${data.icon !== 'undefined' ? `icon={${getIconSnippetWithProps(data.icon as string)}}` : ''}
     ${data.collapseIcon !== 'undefined' ? `collapseIcon={${getIconSnippetWithProps(data.collapseIcon as string)}}` : ''}
     ${data.expandIcon !== 'undefined' ? `expandIcon={${getIconSnippetWithProps(data.expandIcon as string)}}` : ''}
-/>`.replace(/^\s*$(?:\r\n?|\n)/gm, '');
+/>`
+        .replace(/^\s*$(?:\r\n?|\n)/gm, '')
+        .replace(/(?:^|)( {4}|\t)/gm, '    ');
 
 export const DrawerNavItemPlaygroundComponent = (): JSX.Element => (
     <Box

--- a/docs/src/componentDocs/DrawerRailItem/playground/PlaygroundPage.tsx
+++ b/docs/src/componentDocs/DrawerRailItem/playground/PlaygroundPage.tsx
@@ -139,7 +139,9 @@ const generateSnippet: CodeSnippetFunction = (data) =>
     `<DrawerRailItem
     ${getPropsToString(getPropsMapping(data, inputConfig), { join: '\n\t', skip: ['icon', 'condensed'] })}
     ${data.icon !== 'undefined' ? `icon={${getIconSnippetWithProps(data.icon as string)}}` : ''}
-/>`.replace(/^\s*$(?:\r\n?|\n)/gm, '');
+/>`
+        .replace(/^\s*$(?:\r\n?|\n)/gm, '')
+        .replace(/(?:^|)( {4}|\t)/gm, '    ');
 
 export const DrawerRailItemPlaygroundComponent = (): JSX.Element => (
     <Box

--- a/docs/src/componentDocs/DrawerSubheader/playground/PlaygroundPage.tsx
+++ b/docs/src/componentDocs/DrawerSubheader/playground/PlaygroundPage.tsx
@@ -94,7 +94,9 @@ const generateSnippet: CodeSnippetFunction = (data) =>
     ${getPropsToString(getPropsMapping(data, inputConfig), { join: '\n\t', skip: ['open'] })}
 >
     <Box sx={{ p: 2 }}>Subheader Content Here</Box>
-</DrawerSubheader>`.replace(/^\s*$(?:\r\n?|\n)/gm, '');
+</DrawerSubheader>`
+        .replace(/^\s*$(?:\r\n?|\n)/gm, '')
+        .replace(/(?:^|)( {4}|\t)/gm, '    ');
 
 export const DrawerSubheaderPlaygroundComponent = (): JSX.Element => (
     <Box

--- a/docs/src/componentDocs/EmptyState/playground/PlaygroundPage.tsx
+++ b/docs/src/componentDocs/EmptyState/playground/PlaygroundPage.tsx
@@ -97,7 +97,9 @@ const generateSnippet: CodeSnippetFunction = (data) =>
     }`
             : ''
     }
-/>`.replace(/^\s*$(?:\r\n?|\n)/gm, '');
+/>`
+        .replace(/^\s*$(?:\r\n?|\n)/gm, '')
+        .replace(/(?:^|)( {4}|\t)/gm, '    ');
 
 export const EmptyStatePlaygroundComponent = (): JSX.Element => (
     <Box

--- a/docs/src/componentDocs/Hero/playground/PlaygroundPage.tsx
+++ b/docs/src/componentDocs/Hero/playground/PlaygroundPage.tsx
@@ -162,7 +162,9 @@ const generateSnippet: CodeSnippetFunction = (data) =>
                 : ''
         }
     }}
-/>`.replace(/^\s*$(?:\r\n?|\n)/gm, '');
+/>`
+        .replace(/^\s*$(?:\r\n?|\n)/gm, '')
+        .replace(/(?:^|)( {4}|\t)/gm, '    ');
 
 export const HeroPlaygroundComponent = (): JSX.Element => (
     <Box

--- a/docs/src/componentDocs/InfoListItem/playground/PlaygroundPage.tsx
+++ b/docs/src/componentDocs/InfoListItem/playground/PlaygroundPage.tsx
@@ -240,7 +240,9 @@ const generateSnippet: CodeSnippetFunction = (data) =>
     ${getPropsToString(getPropsMapping(data, inputConfig), { join: '\n\t', skip: ['icon', 'clickable'] })}
     ${data.icon && data.icon !== 'undefined' ? `icon={${getIconSnippetWithProps(data.icon as string)}}` : ''}
     ${data.clickable ? `onClick={(): void => {}}` : ``}
-/>`.replace(/^\s*$(?:\r\n?|\n)/gm, '');
+/>`
+        .replace(/^\s*$(?:\r\n?|\n)/gm, '')
+        .replace(/(?:^|)( {4}|\t)/gm, '    ');
 
 export const InfoListItemPlaygroundComponent = (): JSX.Element => (
     <Box

--- a/docs/src/componentDocs/ListItemTag/playground/PlaygroundPage.tsx
+++ b/docs/src/componentDocs/ListItemTag/playground/PlaygroundPage.tsx
@@ -60,7 +60,9 @@ const ListItemTagPreview: PreviewComponent = ({ data }) => {
 const generateSnippet: CodeSnippetFunction = (data) =>
     `<ListItemTag 
     ${getPropsToString(getPropsMapping(data, inputConfig), { join: '\n\t' })}
-/>`.replace(/^\s*$(?:\r\n?|\n)/gm, '');
+/>`
+        .replace(/^\s*$(?:\r\n?|\n)/gm, '')
+        .replace(/(?:^|)( {4}|\t)/gm, '    ');
 
 export const ListItemTagPlaygroundComponent = (): JSX.Element => (
     <Box

--- a/docs/src/componentDocs/ScoreCard/playground/PlaygroundPage.tsx
+++ b/docs/src/componentDocs/ScoreCard/playground/PlaygroundPage.tsx
@@ -254,7 +254,9 @@ const generateSnippet: CodeSnippetFunction = (data) =>
         icon={<Cloud />}
     />
     </List>
-</ScoreCard>`.replace(/^\s*$(?:\r\n?|\n)/gm, '');
+</ScoreCard>`
+        .replace(/^\s*$(?:\r\n?|\n)/gm, '')
+        .replace(/(?:^|)( {4}|\t)/gm, '    ');
 
 export const ScoreCardPlaygroundComponent = (): JSX.Element => (
     <Box

--- a/docs/src/componentDocs/ThreeLiner/playground/PlaygroundPage.tsx
+++ b/docs/src/componentDocs/ThreeLiner/playground/PlaygroundPage.tsx
@@ -61,7 +61,9 @@ const ThreeLinerPreview: PreviewComponent = ({ data }) => {
 const generateSnippet: CodeSnippetFunction = (data) =>
     `<ThreeLiner 
     ${getPropsToString(getPropsMapping(data, inputConfig), { join: '\n\t' })}
-/>`.replace(/^\s*$(?:\r\n?|\n)/gm, '');
+/>`
+        .replace(/^\s*$(?:\r\n?|\n)/gm, '')
+        .replace(/(?:^|)( {4}|\t)/gm, '    ');
 
 export const ThreeLinerPlaygroundComponent = (): JSX.Element => (
     <Box

--- a/docs/src/componentDocs/ToolbarMenu/playground/PlaygroundPage.tsx
+++ b/docs/src/componentDocs/ToolbarMenu/playground/PlaygroundPage.tsx
@@ -92,7 +92,9 @@ const generateSnippet: CodeSnippetFunction = (data) =>
             },
         ],
     }]}
-/>`.replace(/^\s*$(?:\r\n?|\n)/gm, '');
+/>`
+        .replace(/^\s*$(?:\r\n?|\n)/gm, '')
+        .replace(/(?:^|)( {4}|\t)/gm, '    ');
 
 export const ToolbarMenuPlaygroundComponent = (): JSX.Element => (
     <Box

--- a/docs/src/componentDocs/UserMenu/playground/PlaygroundPage.tsx
+++ b/docs/src/componentDocs/UserMenu/playground/PlaygroundPage.tsx
@@ -126,7 +126,9 @@ const generateSnippet: CodeSnippetFunction = (data) =>
             ],
         },
     ]}
-/>`.replace(/^\s*$(?:\r\n?|\n)/gm, '');
+/>`
+        .replace(/^\s*$(?:\r\n?|\n)/gm, '')
+        .replace(/(?:^|)( {4}|\t)/gm, '    ');
 
 export const UserMenuPlaygroundComponent = (): JSX.Element => (
     <Box


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes https://github.com/etn-ccis/blui-react-component-library/issues/829.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- add additional expression to replace tabs with spaces
-
-

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

-

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- go to dev site app-bar https://brightlayer-ui-components.github.io/react-dev/components/app-bar/playground
- toggle and change collapsedHeight, expandedHeight & scrollThreshold
- copy paste playground code snippet in a new file in editor/IDE
- notice expandedHeight & scrollThreshold props are indented with tab and collapsedHeight is spaces
- go to deployed site app-bar https://blui-react-docs--pr846-fix-blui-5257-remove-04v0iflc.web.app/components/app-bar/playground
- toggle and change collapsedHeight, expandedHeight & scrollThreshold
- copy paste playground code snippet in a new file in editor/IDE
- notice expandedHeight, scrollThreshold collapsedHeight are spaces

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
