### PR TITLE
Use router  icon not routerIcon

### DIFF
--- a/docs/src/componentDocs/EmptyState/playground/PlaygroundPage.tsx
+++ b/docs/src/componentDocs/EmptyState/playground/PlaygroundPage.tsx
@@ -22,7 +22,7 @@ const inputConfig: InputConfig = [
         typeLabel: 'ReactNode',
         description: 'The primary icon',
         initialValue: '<Devices />',
-        options: ['<Devices />', '<RouterIcon />', '<SensorsOff />'],
+        options: ['<Devices />', '<Router />', '<SensorsOff />'],
         required: true,
         category: 'Required Props',
     },

--- a/docs/src/shared/utilities.tsx
+++ b/docs/src/shared/utilities.tsx
@@ -11,7 +11,7 @@ import Menu from '@mui/icons-material/Menu';
 import Place from '@mui/icons-material/Place';
 import PinDrop from '@mui/icons-material/PinDrop';
 import Remove from '@mui/icons-material/Remove';
-import RouterIcon from '@mui/icons-material/Router';
+import Router from '@mui/icons-material/Router';
 import SensorsOff from '@mui/icons-material/SensorsOff';
 import TrendingUp from '@mui/icons-material/TrendingUp';
 import TrendingDown from '@mui/icons-material/TrendingDown';
@@ -88,8 +88,8 @@ export const getIcon = (icon: string, iconProps?: SvgIconProps): JSX.Element | u
             return React.createElement(PinDrop, iconProps);
         case '<Remove />':
             return React.createElement(Remove, iconProps);
-        case '<RouterIcon />':
-            return React.createElement(RouterIcon, iconProps);
+        case '<Router />':
+            return React.createElement(Router, iconProps);
         case '<SensorsOff />':
             return React.createElement(SensorsOff, iconProps);
         case '<TrendingUp />':


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes BLUI-5259 .

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- update to import router icon and use it
-
-

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

-

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- https://blui-react-docs--pr848-fix-blui-5259-use-ro-g4csbc8q.web.app/components/empty-state/playground
- select router for icon

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
