### PR TITLE
update width calc

### DIFF
--- a/docs/src/componentDocs/Drawer/playground/PlaygroundPage.tsx
+++ b/docs/src/componentDocs/Drawer/playground/PlaygroundPage.tsx
@@ -246,7 +246,8 @@ const DrawerPreview: PreviewComponent = ({ data }) => {
                     sx={{
                         backgroundColor: 'background.paper',
                         height: 350,
-                        maxWidth: 700,
+                        width: `calc(100vw - 15vw)`,
+                        maxWidth: 650,
                     }}
                 >
                     {rail ? (


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes https://github.com/etn-ccis/blui-react-component-library/issues/806.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- update width calc & max width
-
-

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

-

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- https://blui-react-docs--pr850-bug-blui-5256-mobile-s6pe8xfp.web.app/components/drawer/playground
- resize view using dev tools

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

- The drawer is using noLayout prop and default size is 360px and on small devices the item nav group chevron is cut off from view. Should the example be updated for this?
- Also wondering if a different calculation should be done here for Box component? 
