### PR TITLE
remove classes from combine function

### DIFF
--- a/components/.eslintrc.js
+++ b/components/.eslintrc.js
@@ -11,6 +11,7 @@ module.exports = {
     },
     rules: {
         '@typescript-eslint/no-empty-function': 'off',
+        "@typescript-eslint/no-unused-vars": ["error", { "ignoreRestSiblings": true }],
         'no-empty-function': 'off',
         '@typescript-eslint/naming-convention': [
             'error',

--- a/components/.eslintrc.js
+++ b/components/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports = {
     parser: '@typescript-eslint/parser',
     plugins: ["jest-dom", "testing-library"],
-    extends: ['@brightlayer-ui/eslint-config/tsx'],
+    extends: ['@brightlayer-ui/eslint-config/tsx', 'plugin:react-hooks/recommended'],
     parserOptions: {
         project: './tsconfig.json',
     },

--- a/components/package.json
+++ b/components/package.json
@@ -24,7 +24,7 @@
         "@emotion/react": "^11.10.5",
         "@emotion/styled": "^11.10.5",
         "@mui/icons-material": "^5.10.9",
-        "@mui/material": "^5.10.13",
+        "@mui/material": "^5.15.11",
         "@testing-library/jest-dom": "^6.1.3",
         "@testing-library/react": "^13.4.0",
         "@types/color": "^3.0.3",

--- a/components/package.json
+++ b/components/package.json
@@ -37,6 +37,7 @@
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-jest-dom": "^4.0.3",
         "eslint-plugin-react": "^7.29.4",
+        "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-testing-library": "^5.9.1",
         "jest": "^29.3.1",
         "jest-environment-jsdom": "^29.3.1",

--- a/components/src/core/AppBar/AppBar.tsx
+++ b/components/src/core/AppBar/AppBar.tsx
@@ -248,7 +248,7 @@ const AppBarRender: React.ForwardRefRenderFunction<unknown, AppBarProps> = (prop
                 />
             );
         }
-    }, [backgroundImage, generatedClasses, classes, isExpanded]);
+    }, [backgroundImage, generatedClasses, isExpanded]);
 
     // This handler checks if the scrolling variable is true and adjusts the offset accordingly
     // We do not do this directly in the scroll event callback for performance reasons

--- a/components/src/core/AppBar/AppBar.tsx
+++ b/components/src/core/AppBar/AppBar.tsx
@@ -242,9 +242,8 @@ const AppBarRender: React.ForwardRefRenderFunction<unknown, AppBarProps> = (prop
         if (backgroundImage) {
             return (
                 <div
-                    className={clsx(generatedClasses.background, classes.background, {
+                    className={clsx(generatedClasses.background, {
                         [generatedClasses.expandedBackground]: isExpanded,
-                        [classes.expandedBackground]: isExpanded,
                     })}
                 />
             );
@@ -289,8 +288,8 @@ const AppBarRender: React.ForwardRefRenderFunction<unknown, AppBarProps> = (prop
             className={cx(
                 generatedClasses.root,
                 {
-                    [classes.expanded]: isExpanded,
-                    [classes.collapsed]: !isExpanded,
+                    [generatedClasses.expanded]: isExpanded,
+                    [generatedClasses.collapsed]: !isExpanded,
                 },
                 userClassName
             )}

--- a/components/src/core/AppBar/AppBar.tsx
+++ b/components/src/core/AppBar/AppBar.tsx
@@ -152,7 +152,7 @@ const AppBarRender: React.ForwardRefRenderFunction<unknown, AppBarProps> = (prop
     const scrollElement = scrollContainerId ? document.getElementById(scrollContainerId) : null;
     const scrollTop = scrollElement ? scrollElement.scrollTop : window.scrollY;
 
-    const defaultClasses = useUtilityClasses(props);
+    const generatedClasses = useUtilityClasses(props);
     const animationDuration = durationProp || theme.transitions.duration.standard;
 
     const [offset, setOffset] = useState(0);
@@ -242,14 +242,14 @@ const AppBarRender: React.ForwardRefRenderFunction<unknown, AppBarProps> = (prop
         if (backgroundImage) {
             return (
                 <div
-                    className={clsx(defaultClasses.background, classes.background, {
-                        [defaultClasses.expandedBackground]: isExpanded,
+                    className={clsx(generatedClasses.background, classes.background, {
+                        [generatedClasses.expandedBackground]: isExpanded,
                         [classes.expandedBackground]: isExpanded,
                     })}
                 />
             );
         }
-    }, [backgroundImage, defaultClasses, classes, isExpanded]);
+    }, [backgroundImage, generatedClasses, classes, isExpanded]);
 
     // This handler checks if the scrolling variable is true and adjusts the offset accordingly
     // We do not do this directly in the scroll event callback for performance reasons
@@ -287,7 +287,7 @@ const AppBarRender: React.ForwardRefRenderFunction<unknown, AppBarProps> = (prop
             {...muiAppBarProps}
             data-testid={'blui-appbar-root'}
             className={cx(
-                defaultClasses.root,
+                generatedClasses.root,
                 {
                     [classes.expanded]: isExpanded,
                     [classes.collapsed]: !isExpanded,

--- a/components/src/core/AppBar/AppBar.tsx
+++ b/components/src/core/AppBar/AppBar.tsx
@@ -288,7 +288,6 @@ const AppBarRender: React.ForwardRefRenderFunction<unknown, AppBarProps> = (prop
             data-testid={'blui-appbar-root'}
             className={cx(
                 defaultClasses.root,
-                classes.root,
                 {
                     [classes.expanded]: isExpanded,
                     [classes.collapsed]: !isExpanded,

--- a/components/src/core/AppBar/AppBar.tsx
+++ b/components/src/core/AppBar/AppBar.tsx
@@ -141,7 +141,6 @@ const AppBarRender: React.ForwardRefRenderFunction<unknown, AppBarProps> = (prop
         expandedHeight = 200,
         backgroundImage,
         className: userClassName,
-        classes = {},
         collapsedHeight = defaultAppBarHeight,
         // onExpandedHeightReached,
         // onCollapsedHeightReached,

--- a/components/src/core/AppBar/AppBar.tsx
+++ b/components/src/core/AppBar/AppBar.tsx
@@ -206,7 +206,7 @@ const AppBarRender: React.ForwardRefRenderFunction<unknown, AppBarProps> = (prop
         else if (previousOffset > 0 && offset === 0) {
             expandToolbar();
         }
-    }, [offset, scrollThreshold]);
+    }, [offset, scrollThreshold, animating, collapseToolbar, expandToolbar, previousOffset, variant]);
 
     // Properly update the height whenever the variant property changes
     useEffect(() => {
@@ -221,7 +221,7 @@ const AppBarRender: React.ForwardRefRenderFunction<unknown, AppBarProps> = (prop
                 expandToolbar();
             }
         }
-    }, [variant]);
+    }, [variant, collapseToolbar, expandToolbar, offset, scrollThreshold]);
 
     // Properly update the size when either height property changes
     useEffect(() => {
@@ -234,7 +234,15 @@ const AppBarRender: React.ForwardRefRenderFunction<unknown, AppBarProps> = (prop
         } else {
             expandToolbar();
         }
-    }, [collapsedHeight, expandedHeight]);
+    }, [
+        collapsedHeight,
+        expandedHeight,
+        collapseToolbar,
+        expandToolbar,
+        height,
+        previousCollapsedHeight,
+        previousExpandedHeight,
+    ]);
 
     // Returns the background image to apply on the app bar
     const getBackgroundImage = useCallback((): JSX.Element | undefined => {
@@ -265,7 +273,7 @@ const AppBarRender: React.ForwardRefRenderFunction<unknown, AppBarProps> = (prop
             setOffset(scrollTop);
             setEndScrollHandled(true);
         }
-    }, [scrolling, animating, offset, endScrollHandled]);
+    }, [scrolling, animating, offset, endScrollHandled, scrollTop]);
 
     // This function listens for scroll events on the window and sets the scrolling variable to true
     useEffect(() => {
@@ -277,7 +285,7 @@ const AppBarRender: React.ForwardRefRenderFunction<unknown, AppBarProps> = (prop
             clearInterval(scrollCheck);
             (scrollElement || window).removeEventListener('scroll', () => setScrolling(true));
         };
-    }, [handleScroll]);
+    }, [handleScroll, scrollElement]);
 
     return (
         <Root

--- a/components/src/core/AppBar/AppBar.tsx
+++ b/components/src/core/AppBar/AppBar.tsx
@@ -207,7 +207,8 @@ const AppBarRender: React.ForwardRefRenderFunction<unknown, AppBarProps> = (prop
         else if (previousOffset > 0 && offset === 0) {
             expandToolbar();
         }
-    }, [offset, scrollThreshold, animating, collapseToolbar, expandToolbar, previousOffset, variant]);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [offset, scrollThreshold]);
 
     // Properly update the height whenever the variant property changes
     useEffect(() => {
@@ -222,7 +223,8 @@ const AppBarRender: React.ForwardRefRenderFunction<unknown, AppBarProps> = (prop
                 expandToolbar();
             }
         }
-    }, [variant, collapseToolbar, expandToolbar, offset, scrollThreshold]);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [variant]);
 
     // Properly update the size when either height property changes
     useEffect(() => {
@@ -235,15 +237,8 @@ const AppBarRender: React.ForwardRefRenderFunction<unknown, AppBarProps> = (prop
         } else {
             expandToolbar();
         }
-    }, [
-        collapsedHeight,
-        expandedHeight,
-        collapseToolbar,
-        expandToolbar,
-        height,
-        previousCollapsedHeight,
-        previousExpandedHeight,
-    ]);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [collapsedHeight, expandedHeight]);
 
     // Returns the background image to apply on the app bar
     const getBackgroundImage = useCallback((): JSX.Element | undefined => {
@@ -274,7 +269,8 @@ const AppBarRender: React.ForwardRefRenderFunction<unknown, AppBarProps> = (prop
             setOffset(scrollTop);
             setEndScrollHandled(true);
         }
-    }, [animating, scrolling, scrollTop, offset, endScrollHandled]);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [scrolling, offset, endScrollHandled]);
 
     // listen for animating to finish and update scroll position
     useEffect(() => {

--- a/components/src/core/AppBar/AppBar.tsx
+++ b/components/src/core/AppBar/AppBar.tsx
@@ -166,10 +166,10 @@ const AppBarRender: React.ForwardRefRenderFunction<unknown, AppBarProps> = (prop
         variant === 'collapsed'
             ? collapsedHeight
             : variant === 'expanded'
-                ? expandedHeight
-                : scrollTop > scrollThreshold
-                    ? collapsedHeight
-                    : expandedHeight
+            ? expandedHeight
+            : scrollTop > scrollThreshold
+            ? collapsedHeight
+            : expandedHeight
     );
     const isExpanded = height === expandedHeight;
 

--- a/components/src/core/ChannelValue/ChannelValue.tsx
+++ b/components/src/core/ChannelValue/ChannelValue.tsx
@@ -139,7 +139,7 @@ const ChannelValueRender: React.ForwardRefRenderFunction<unknown, ChannelValuePr
                     <Unit
                         variant={'h6'}
                         color={'inherit'}
-                        className={cx(defaultClasses.text, classes.text, defaultClasses.units, classes.units)}
+                        className={cx(defaultClasses.text, defaultClasses.units)}
                         isSuffix={applySuffix()}
                         data-testid={'blui-channel-value-units'}
                     >
@@ -155,14 +155,14 @@ const ChannelValueRender: React.ForwardRefRenderFunction<unknown, ChannelValuePr
         <Root
             component="span"
             ref={ref}
-            className={cx(defaultClasses.root, classes.root, userClassName)}
+            className={cx(defaultClasses.root, userClassName)}
             data-testid={'blui-channel-value-root'}
             fontSize={fontSize}
             color={color}
             {...otherProps}
         >
             {icon && (
-                <IconSpan className={cx(defaultClasses.icon, classes.icon)} data-testid={'blui-channel-value-icon'}>
+                <IconSpan className={cx(defaultClasses.icon)} data-testid={'blui-channel-value-icon'}>
                     {changeIconDisplay(icon)}
                 </IconSpan>
             )}
@@ -170,7 +170,7 @@ const ChannelValueRender: React.ForwardRefRenderFunction<unknown, ChannelValuePr
             <Value
                 variant={'h6'}
                 color={'inherit'}
-                className={cx(defaultClasses.text, classes.text, defaultClasses.value, classes.value)}
+                className={cx(defaultClasses.text, defaultClasses.value)}
                 data-testid={'blui-channel-value-value'}
                 isPrefix={applyPrefix()}
             >

--- a/components/src/core/ChannelValue/ChannelValue.tsx
+++ b/components/src/core/ChannelValue/ChannelValue.tsx
@@ -148,7 +148,7 @@ const ChannelValueRender: React.ForwardRefRenderFunction<unknown, ChannelValuePr
                 )}
             </>
         ),
-        [units, prefix, classes, generatedClasses, unitSpace]
+        [units, prefix, generatedClasses, unitSpace]
     );
 
     return (

--- a/components/src/core/ChannelValue/ChannelValue.tsx
+++ b/components/src/core/ChannelValue/ChannelValue.tsx
@@ -162,7 +162,7 @@ const ChannelValueRender: React.ForwardRefRenderFunction<unknown, ChannelValuePr
             {...otherProps}
         >
             {icon && (
-                <IconSpan className={(generatedClasses.icon)} data-testid={'blui-channel-value-icon'}>
+                <IconSpan className={generatedClasses.icon} data-testid={'blui-channel-value-icon'}>
                     {changeIconDisplay(icon)}
                 </IconSpan>
             )}

--- a/components/src/core/ChannelValue/ChannelValue.tsx
+++ b/components/src/core/ChannelValue/ChannelValue.tsx
@@ -116,7 +116,7 @@ const ChannelValueRender: React.ForwardRefRenderFunction<unknown, ChannelValuePr
         fontSize,
         ...otherProps
     } = props;
-    const defaultClasses = useUtilityClasses(props);
+    const generatedClasses = useUtilityClasses(props);
     const prefixUnitAllowSpaceList = ['$'];
     const suffixUnitAllowSpaceList = ['%', '℉', '°F', '℃', '°C', '°'];
 
@@ -139,7 +139,7 @@ const ChannelValueRender: React.ForwardRefRenderFunction<unknown, ChannelValuePr
                     <Unit
                         variant={'h6'}
                         color={'inherit'}
-                        className={cx(defaultClasses.text, defaultClasses.units)}
+                        className={cx(generatedClasses.text, generatedClasses.units)}
                         isSuffix={applySuffix()}
                         data-testid={'blui-channel-value-units'}
                     >
@@ -148,21 +148,21 @@ const ChannelValueRender: React.ForwardRefRenderFunction<unknown, ChannelValuePr
                 )}
             </>
         ),
-        [units, prefix, classes, defaultClasses, unitSpace]
+        [units, prefix, classes, generatedClasses, unitSpace]
     );
 
     return (
         <Root
             component="span"
             ref={ref}
-            className={cx(defaultClasses.root, userClassName)}
+            className={cx(generatedClasses.root, userClassName)}
             data-testid={'blui-channel-value-root'}
             fontSize={fontSize}
             color={color}
             {...otherProps}
         >
             {icon && (
-                <IconSpan className={cx(defaultClasses.icon)} data-testid={'blui-channel-value-icon'}>
+                <IconSpan className={(generatedClasses.icon)} data-testid={'blui-channel-value-icon'}>
                     {changeIconDisplay(icon)}
                 </IconSpan>
             )}
@@ -170,7 +170,7 @@ const ChannelValueRender: React.ForwardRefRenderFunction<unknown, ChannelValuePr
             <Value
                 variant={'h6'}
                 color={'inherit'}
-                className={cx(defaultClasses.text, defaultClasses.value)}
+                className={cx(generatedClasses.text, generatedClasses.value)}
                 data-testid={'blui-channel-value-value'}
                 isPrefix={applyPrefix()}
             >

--- a/components/src/core/ChannelValue/ChannelValue.tsx
+++ b/components/src/core/ChannelValue/ChannelValue.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback } from 'react';
 import Typography, { TypographyProps } from '@mui/material/Typography';
 import { cx } from '@emotion/css';
 import PropTypes from 'prop-types';
@@ -100,6 +100,9 @@ const changeIconDisplay = (newIcon: JSX.Element): JSX.Element =>
         style: Object.assign({}, newIcon.props.style, { display: 'block', fontSize: 'inherit' }),
     });
 
+const prefixUnitAllowSpaceList = ['$'];
+const suffixUnitAllowSpaceList = ['%', '℉', '°F', '℃', '°C', '°'];
+
 const ChannelValueRender: React.ForwardRefRenderFunction<unknown, ChannelValueProps> = (
     props: ChannelValueProps,
     ref: any
@@ -117,21 +120,17 @@ const ChannelValueRender: React.ForwardRefRenderFunction<unknown, ChannelValuePr
         ...otherProps
     } = props;
     const generatedClasses = useUtilityClasses(props);
-    // const prefixUnitAllowSpaceList = ['$'];
-    const prefixUnitAllowSpaceList = useMemo(() => ['$'], []);
-    // const suffixUnitAllowSpaceList = ['%', '℉', '°F', '℃', '°C', '°'];
-    const suffixUnitAllowSpaceList = useMemo(() => ['%', '℉', '°F', '℃', '°C', '°'], []);
 
     const applyPrefix = useCallback(
         (): boolean =>
             prefix && unitSpace !== 'hide' && (unitSpace === 'show' || !prefixUnitAllowSpaceList.includes(units)),
-        [prefix, units, unitSpace, prefixUnitAllowSpaceList]
+        [prefix, units, unitSpace]
     );
 
     const applySuffix = useCallback(
         (): boolean =>
             !prefix && unitSpace !== 'hide' && (unitSpace === 'show' || !suffixUnitAllowSpaceList.includes(units)),
-        [prefix, units, unitSpace, suffixUnitAllowSpaceList]
+        [prefix, units, unitSpace]
     );
 
     const getUnitElement = useCallback(

--- a/components/src/core/ChannelValue/ChannelValue.tsx
+++ b/components/src/core/ChannelValue/ChannelValue.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import Typography, { TypographyProps } from '@mui/material/Typography';
 import { cx } from '@emotion/css';
 import PropTypes from 'prop-types';
@@ -117,19 +117,21 @@ const ChannelValueRender: React.ForwardRefRenderFunction<unknown, ChannelValuePr
         ...otherProps
     } = props;
     const generatedClasses = useUtilityClasses(props);
-    const prefixUnitAllowSpaceList = ['$'];
-    const suffixUnitAllowSpaceList = ['%', '℉', '°F', '℃', '°C', '°'];
+    // const prefixUnitAllowSpaceList = ['$'];
+    const prefixUnitAllowSpaceList = useMemo(() => ['$'], []);
+    // const suffixUnitAllowSpaceList = ['%', '℉', '°F', '℃', '°C', '°'];
+    const suffixUnitAllowSpaceList = useMemo(() => ['%', '℉', '°F', '℃', '°C', '°'], []);
 
     const applyPrefix = useCallback(
         (): boolean =>
             prefix && unitSpace !== 'hide' && (unitSpace === 'show' || !prefixUnitAllowSpaceList.includes(units)),
-        [prefix, units, unitSpace]
+        [prefix, units, unitSpace, prefixUnitAllowSpaceList]
     );
 
     const applySuffix = useCallback(
         (): boolean =>
             !prefix && unitSpace !== 'hide' && (unitSpace === 'show' || !suffixUnitAllowSpaceList.includes(units)),
-        [prefix, units, unitSpace]
+        [prefix, units, unitSpace, suffixUnitAllowSpaceList]
     );
 
     const getUnitElement = useCallback(
@@ -148,7 +150,7 @@ const ChannelValueRender: React.ForwardRefRenderFunction<unknown, ChannelValuePr
                 )}
             </>
         ),
-        [units, prefix, generatedClasses, unitSpace]
+        [units, generatedClasses, applySuffix]
     );
 
     return (

--- a/components/src/core/Drawer/Drawer.tsx
+++ b/components/src/core/Drawer/Drawer.tsx
@@ -123,7 +123,6 @@ const Content = styled(
 const DrawerRenderer: React.ForwardRefRenderFunction<unknown, DrawerProps> = (props: DrawerProps, ref: any) => {
     const hoverDelay = useRef<NodeJS.Timeout | null>(null);
     const generatedClasses = useUtilityClasses(props);
-    // const theme = useTheme();
     const { setPadding, setDrawerOpen } = useDrawerLayout();
     const [hover, setHover] = useState(false);
     const {

--- a/components/src/core/Drawer/Drawer.tsx
+++ b/components/src/core/Drawer/Drawer.tsx
@@ -320,7 +320,6 @@ const DrawerRenderer: React.ForwardRefRenderFunction<unknown, DrawerProps> = (pr
                 }),
                 paper: clsx(generatedClasses.paper, {
                     [generatedClasses.sideBorder]: sideBorder,
-                    [classes.sideBorder]: sideBorder && classes.sideBorder,
                 }),
             }}
             backgroundColor={backgroundColor}

--- a/components/src/core/Drawer/Drawer.tsx
+++ b/components/src/core/Drawer/Drawer.tsx
@@ -227,6 +227,7 @@ const DrawerRenderer: React.ForwardRefRenderFunction<unknown, DrawerProps> = (pr
             activeItemBackgroundShape,
             activeItemFontColor,
             activeItemIconColor,
+            backgroundColor,
             chevron,
             chevronColor,
             collapseIcon,
@@ -239,7 +240,6 @@ const DrawerRenderer: React.ForwardRefRenderFunction<unknown, DrawerProps> = (pr
             nestedBackgroundColor,
             nestedDivider,
             ripple,
-            onItemSelect,
             props.children,
         ]
     );
@@ -306,7 +306,7 @@ const DrawerRenderer: React.ForwardRefRenderFunction<unknown, DrawerProps> = (pr
             setPadding(variant === 'temporary' ? 0 : getDrawerWidth());
             setDrawerOpen(isDrawerOpen());
         }
-    }, [variant, noLayout, isDrawerOpen, getDrawerWidth]);
+    }, [variant, noLayout, isDrawerOpen, getDrawerWidth, setDrawerOpen, setPadding]);
 
     return (
         <Root

--- a/components/src/core/Drawer/Drawer.tsx
+++ b/components/src/core/Drawer/Drawer.tsx
@@ -317,7 +317,6 @@ const DrawerRenderer: React.ForwardRefRenderFunction<unknown, DrawerProps> = (pr
             classes={{
                 root: clsx(generatedClasses.root, className, {
                     [generatedClasses.expanded]: isDrawerOpen(),
-                    [classes.expanded]: isDrawerOpen() && classes.expanded,
                 }),
                 paper: clsx(generatedClasses.paper, classes.paper, {
                     [generatedClasses.sideBorder]: sideBorder,

--- a/components/src/core/Drawer/Drawer.tsx
+++ b/components/src/core/Drawer/Drawer.tsx
@@ -342,7 +342,7 @@ const DrawerRenderer: React.ForwardRefRenderFunction<unknown, DrawerProps> = (pr
                     activeItem: activeItem,
                 }}
             >
-                <Content className={cx(defaultClasses.content, classes.content)} style={{ width: getContentWidth() }}>
+                <Content className={cx(defaultClasses.content)} style={{ width: getContentWidth() }}>
                     {getDrawerContents()}
                 </Content>
             </DrawerContext.Provider>

--- a/components/src/core/Drawer/Drawer.tsx
+++ b/components/src/core/Drawer/Drawer.tsx
@@ -305,7 +305,8 @@ const DrawerRenderer: React.ForwardRefRenderFunction<unknown, DrawerProps> = (pr
             setPadding(variant === 'temporary' ? 0 : getDrawerWidth());
             setDrawerOpen(isDrawerOpen());
         }
-    }, [variant, noLayout, isDrawerOpen, getDrawerWidth, setDrawerOpen, setPadding]);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [variant, noLayout, isDrawerOpen, getDrawerWidth]);
 
     return (
         <Root

--- a/components/src/core/Drawer/Drawer.tsx
+++ b/components/src/core/Drawer/Drawer.tsx
@@ -315,7 +315,7 @@ const DrawerRenderer: React.ForwardRefRenderFunction<unknown, DrawerProps> = (pr
             variant={variant === 'temporary' ? variant : 'permanent'}
             open={isDrawerOpen()}
             classes={{
-                root: clsx(generatedClasses.root, classes.root, className, {
+                root: clsx(generatedClasses.root, className, {
                     [generatedClasses.expanded]: isDrawerOpen(),
                     [classes.expanded]: isDrawerOpen() && classes.expanded,
                 }),

--- a/components/src/core/Drawer/Drawer.tsx
+++ b/components/src/core/Drawer/Drawer.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useEffect, useState, useCallback, useRef } from 'react';
 import PropTypes from 'prop-types';
-import { useTheme, styled } from '@mui/material/styles';
+import { styled } from '@mui/material/styles';
 import MUIDrawer, { DrawerProps as MUIDrawerProps } from '@mui/material/Drawer';
 import { DrawerBodyProps } from './DrawerBody';
 import { useDrawerLayout } from '../DrawerLayout/contexts/DrawerLayoutContextProvider';
@@ -121,9 +121,9 @@ const Content = styled(
 }));
 
 const DrawerRenderer: React.ForwardRefRenderFunction<unknown, DrawerProps> = (props: DrawerProps, ref: any) => {
-    let hoverDelay: NodeJS.Timeout;
+    const hoverDelay = useRef<NodeJS.Timeout | null>(null);
     const generatedClasses = useUtilityClasses(props);
-    const theme = useTheme();
+    // const theme = useTheme();
     const { setPadding, setDrawerOpen } = useDrawerLayout();
     const [hover, setHover] = useState(false);
     const {
@@ -261,14 +261,14 @@ const DrawerRenderer: React.ForwardRefRenderFunction<unknown, DrawerProps> = (pr
                     onMouseEnter={
                         openOnHover
                             ? (): void => {
-                                  hoverDelay = setTimeout(() => setHover(true), openOnHoverDelay);
+                                  hoverDelay.current = setTimeout(() => setHover(true), openOnHoverDelay);
                               }
                             : undefined
                     }
                     onMouseLeave={
                         openOnHover
                             ? (): void => {
-                                  clearTimeout(hoverDelay);
+                                  clearTimeout(hoverDelay.current);
                                   setHover(false);
                               }
                             : undefined
@@ -280,7 +280,7 @@ const DrawerRenderer: React.ForwardRefRenderFunction<unknown, DrawerProps> = (pr
                 </div>
             </>
         ),
-        [setHover, openOnHover, openOnHoverDelay, getSubHeader, getBody, getFooter]
+        [setHover, openOnHover, openOnHoverDelay, getSubHeader, getHeader, getBody, getFooter]
     );
 
     /* Default Drawer Sizes */
@@ -292,13 +292,13 @@ const DrawerRenderer: React.ForwardRefRenderFunction<unknown, DrawerProps> = (pr
         if (isRail) return condensed ? RAIL_WIDTH_CONDENSED : RAIL_WIDTH;
         if (isDrawerOpen()) return width || EXPANDED_DRAWER_WIDTH_DEFAULT;
         return COLLAPSED_DRAWER_WIDTH_DEFAULT;
-    }, [isRail, condensed, theme, isDrawerOpen, width]);
+    }, [isRail, condensed, isDrawerOpen, width]);
 
     // Get the width of the content inside the drawer - if the drawer is collapsed, content maintains its size in order to clip
     const getContentWidth = useCallback((): number | string => {
         if (isRail) return condensed ? RAIL_WIDTH_CONDENSED : RAIL_WIDTH;
         return width || EXPANDED_DRAWER_WIDTH_DEFAULT;
-    }, [isRail, condensed, width, theme]);
+    }, [isRail, condensed, width]);
 
     // Update the drawer layout padding when the drawer changes
     useEffect(() => {

--- a/components/src/core/Drawer/Drawer.tsx
+++ b/components/src/core/Drawer/Drawer.tsx
@@ -318,7 +318,7 @@ const DrawerRenderer: React.ForwardRefRenderFunction<unknown, DrawerProps> = (pr
                 root: clsx(generatedClasses.root, className, {
                     [generatedClasses.expanded]: isDrawerOpen(),
                 }),
-                paper: clsx(generatedClasses.paper, classes.paper, {
+                paper: clsx(generatedClasses.paper, {
                     [generatedClasses.sideBorder]: sideBorder,
                     [classes.sideBorder]: sideBorder && classes.sideBorder,
                 }),

--- a/components/src/core/Drawer/Drawer.tsx
+++ b/components/src/core/Drawer/Drawer.tsx
@@ -339,7 +339,7 @@ const DrawerRenderer: React.ForwardRefRenderFunction<unknown, DrawerProps> = (pr
                     activeItem: activeItem,
                 }}
             >
-                <Content className={(generatedClasses.content)} style={{ width: getContentWidth() }}>
+                <Content className={generatedClasses.content} style={{ width: getContentWidth() }}>
                     {getDrawerContents()}
                 </Content>
             </DrawerContext.Provider>

--- a/components/src/core/Drawer/Drawer.tsx
+++ b/components/src/core/Drawer/Drawer.tsx
@@ -8,7 +8,6 @@ import { DrawerContext } from './DrawerContext';
 import { NavItemSharedStyleProps, NavItemSharedStylePropTypes, SharedStyleProps, SharedStylePropTypes } from './types';
 import { findChildByType, mergeStyleProp } from './utilities';
 import clsx from 'clsx';
-import { cx } from '@emotion/css';
 import drawerClasses, { DrawerClasses, DrawerClassKey, getDrawerUtilityClass } from './DrawerClasses';
 import { unstable_composeClasses as composeClasses } from '@mui/base';
 import Box from '@mui/material/Box';
@@ -123,7 +122,7 @@ const Content = styled(
 
 const DrawerRenderer: React.ForwardRefRenderFunction<unknown, DrawerProps> = (props: DrawerProps, ref: any) => {
     let hoverDelay: NodeJS.Timeout;
-    const defaultClasses = useUtilityClasses(props);
+    const generatedClasses = useUtilityClasses(props);
     const theme = useTheme();
     const { setPadding, setDrawerOpen } = useDrawerLayout();
     const [hover, setHover] = useState(false);
@@ -316,12 +315,12 @@ const DrawerRenderer: React.ForwardRefRenderFunction<unknown, DrawerProps> = (pr
             variant={variant === 'temporary' ? variant : 'permanent'}
             open={isDrawerOpen()}
             classes={{
-                root: clsx(defaultClasses.root, classes.root, className, {
-                    [defaultClasses.expanded]: isDrawerOpen(),
+                root: clsx(generatedClasses.root, classes.root, className, {
+                    [generatedClasses.expanded]: isDrawerOpen(),
                     [classes.expanded]: isDrawerOpen() && classes.expanded,
                 }),
-                paper: clsx(defaultClasses.paper, classes.paper, {
-                    [defaultClasses.sideBorder]: sideBorder,
+                paper: clsx(generatedClasses.paper, classes.paper, {
+                    [generatedClasses.sideBorder]: sideBorder,
                     [classes.sideBorder]: sideBorder && classes.sideBorder,
                 }),
             }}
@@ -342,7 +341,7 @@ const DrawerRenderer: React.ForwardRefRenderFunction<unknown, DrawerProps> = (pr
                     activeItem: activeItem,
                 }}
             >
-                <Content className={cx(defaultClasses.content)} style={{ width: getContentWidth() }}>
+                <Content className={(generatedClasses.content)} style={{ width: getContentWidth() }}>
                     {getDrawerContents()}
                 </Content>
             </DrawerContext.Provider>

--- a/components/src/core/Drawer/DrawerBody.tsx
+++ b/components/src/core/Drawer/DrawerBody.tsx
@@ -60,6 +60,7 @@ const DrawerBodyRender: React.ForwardRefRenderFunction<unknown, DrawerBodyProps>
         nestedDivider,
         ripple,
         // DrawerBody-specific props
+        classes,
         children: bodyChildren,
         // Other props
         ...otherProps

--- a/components/src/core/Drawer/DrawerBody.tsx
+++ b/components/src/core/Drawer/DrawerBody.tsx
@@ -7,7 +7,6 @@ import Box, { BoxProps } from '@mui/material/Box';
 import { styled } from '@mui/material/styles';
 import { DrawerBodyClasses, DrawerBodyClassKey, getDrawerBodyUtilityClass } from './DrawerBodyClasses';
 import { unstable_composeClasses as composeClasses } from '@mui/base';
-import { cx } from '@emotion/css';
 
 const useUtilityClasses = (ownerState: DrawerBodyProps): Record<DrawerBodyClassKey, string> => {
     const { classes } = ownerState;
@@ -40,7 +39,7 @@ const DrawerBodyRender: React.ForwardRefRenderFunction<unknown, DrawerBodyProps>
     bodyProps: DrawerBodyProps,
     ref: any
 ) => {
-    const defaultClasses = useUtilityClasses(bodyProps);
+    const generatedClasses = useUtilityClasses(bodyProps);
     const {
         // Inheritable Props
         activeItemBackgroundColor,
@@ -72,7 +71,7 @@ const DrawerBodyRender: React.ForwardRefRenderFunction<unknown, DrawerBodyProps>
         <Root
             ref={ref}
             data-testid={'blui-drawer-body'}
-            className={cx(defaultClasses.root)}
+            className={(generatedClasses.root)}
             backgroundColor={backgroundColor}
             {...otherProps}
         >

--- a/components/src/core/Drawer/DrawerBody.tsx
+++ b/components/src/core/Drawer/DrawerBody.tsx
@@ -61,7 +61,6 @@ const DrawerBodyRender: React.ForwardRefRenderFunction<unknown, DrawerBodyProps>
         nestedDivider,
         ripple,
         // DrawerBody-specific props
-        classes,
         children: bodyChildren,
         // Other props
         ...otherProps
@@ -73,7 +72,7 @@ const DrawerBodyRender: React.ForwardRefRenderFunction<unknown, DrawerBodyProps>
         <Root
             ref={ref}
             data-testid={'blui-drawer-body'}
-            className={cx(defaultClasses.root, classes.root)}
+            className={cx(defaultClasses.root)}
             backgroundColor={backgroundColor}
             {...otherProps}
         >

--- a/components/src/core/Drawer/DrawerBody.tsx
+++ b/components/src/core/Drawer/DrawerBody.tsx
@@ -71,7 +71,7 @@ const DrawerBodyRender: React.ForwardRefRenderFunction<unknown, DrawerBodyProps>
         <Root
             ref={ref}
             data-testid={'blui-drawer-body'}
-            className={(generatedClasses.root)}
+            className={generatedClasses.root}
             backgroundColor={backgroundColor}
             {...otherProps}
         >

--- a/components/src/core/Drawer/DrawerFooter/DrawerFooter.tsx
+++ b/components/src/core/Drawer/DrawerFooter/DrawerFooter.tsx
@@ -59,7 +59,6 @@ const DrawerFooterRender: React.ForwardRefRenderFunction<unknown, DrawerFooterPr
 ) => {
     const defaultClasses = useUtilityClasses(props);
     const {
-        classes,
         className: userClassName,
         children,
         divider = true,
@@ -80,9 +79,7 @@ const DrawerFooterRender: React.ForwardRefRenderFunction<unknown, DrawerFooterPr
                 data-testid={'blui-drawer-footer'}
                 className={cx(
                     defaultClasses.root,
-                    classes.root,
                     { [defaultClasses.hidden]: !drawerOpen && hideContentOnCollapse },
-                    { [classes.hidden]: !drawerOpen && hideContentOnCollapse },
                     userClassName
                 )}
                 backgroundColor={backgroundColor}

--- a/components/src/core/Drawer/DrawerFooter/DrawerFooter.tsx
+++ b/components/src/core/Drawer/DrawerFooter/DrawerFooter.tsx
@@ -57,7 +57,7 @@ const DrawerFooterRender: React.ForwardRefRenderFunction<unknown, DrawerFooterPr
     props: DrawerFooterProps,
     ref: any
 ) => {
-    const defaultClasses = useUtilityClasses(props);
+    const generatedClasses = useUtilityClasses(props);
     const {
         className: userClassName,
         children,
@@ -78,8 +78,8 @@ const DrawerFooterRender: React.ForwardRefRenderFunction<unknown, DrawerFooterPr
                 ref={ref}
                 data-testid={'blui-drawer-footer'}
                 className={cx(
-                    defaultClasses.root,
-                    { [defaultClasses.hidden]: !drawerOpen && hideContentOnCollapse },
+                    generatedClasses.root,
+                    { [generatedClasses.hidden]: !drawerOpen && hideContentOnCollapse },
                     userClassName
                 )}
                 backgroundColor={backgroundColor}

--- a/components/src/core/Drawer/DrawerFooter/DrawerFooter.tsx
+++ b/components/src/core/Drawer/DrawerFooter/DrawerFooter.tsx
@@ -59,6 +59,7 @@ const DrawerFooterRender: React.ForwardRefRenderFunction<unknown, DrawerFooterPr
 ) => {
     const generatedClasses = useUtilityClasses(props);
     const {
+        classes,
         className: userClassName,
         children,
         divider = true,

--- a/components/src/core/Drawer/DrawerHeader/DrawerHeader.tsx
+++ b/components/src/core/Drawer/DrawerHeader/DrawerHeader.tsx
@@ -248,7 +248,6 @@ const DrawerHeaderRender: React.ForwardRefRenderFunction<unknown, DrawerHeaderPr
                     <Navigation
                         className={clsx(generatedClasses.navigation, classes.navigation, {
                             [generatedClasses.railIcon]: variant === 'rail' && !condensed,
-                            [classes.railIcon]: variant === 'rail' && !condensed && classes.railIcon,
                             [generatedClasses.nonClickable]: variant === 'rail' && !condensed && !onIconClick,
                         })}
                     >

--- a/components/src/core/Drawer/DrawerHeader/DrawerHeader.tsx
+++ b/components/src/core/Drawer/DrawerHeader/DrawerHeader.tsx
@@ -228,7 +228,7 @@ const DrawerHeaderRender: React.ForwardRefRenderFunction<unknown, DrawerHeaderPr
                     backgroundOpacity={backgroundOpacity}
                 />
             ) : null,
-        [backgroundImage, generatedClasses]
+        [backgroundImage, generatedClasses, backgroundOpacity]
     );
 
     return (

--- a/components/src/core/Drawer/DrawerHeader/DrawerHeader.tsx
+++ b/components/src/core/Drawer/DrawerHeader/DrawerHeader.tsx
@@ -194,11 +194,11 @@ const DrawerHeaderRender: React.ForwardRefRenderFunction<unknown, DrawerHeaderPr
     const getHeaderContent = useCallback(
         (): ReactNode =>
             titleContent || (
-                <Content className={(generatedClasses.content)}>
+                <Content className={generatedClasses.content}>
                     <Title
                         noWrap
                         variant={'h6'}
-                        className={(generatedClasses.title)}
+                        className={generatedClasses.title}
                         data-testid={'blui-drawer-header-title'}
                     >
                         {title}
@@ -208,7 +208,7 @@ const DrawerHeaderRender: React.ForwardRefRenderFunction<unknown, DrawerHeaderPr
                         <Subtitle
                             noWrap
                             variant={'body2'}
-                            className={(generatedClasses.subtitle)}
+                            className={generatedClasses.subtitle}
                             data-testid={'blui-drawer-header-subtitle'}
                         >
                             {subtitle}
@@ -223,7 +223,7 @@ const DrawerHeaderRender: React.ForwardRefRenderFunction<unknown, DrawerHeaderPr
         (): JSX.Element | null =>
             backgroundImage ? (
                 <Background
-                    className={(generatedClasses.background)}
+                    className={generatedClasses.background}
                     backgroundImage={backgroundImage}
                     backgroundOpacity={backgroundOpacity}
                 />
@@ -236,7 +236,7 @@ const DrawerHeaderRender: React.ForwardRefRenderFunction<unknown, DrawerHeaderPr
             <Root
                 ref={ref}
                 data-testid={'blui-drawer-header'}
-                className={(generatedClasses.root)}
+                className={generatedClasses.root}
                 backgroundColor={backgroundColor}
                 fontColor={fontColor}
                 disableGutters={disableGutters}
@@ -264,7 +264,7 @@ const DrawerHeaderRender: React.ForwardRefRenderFunction<unknown, DrawerHeaderPr
                             </IconButton>
                         )}
                         {!onIconClick && (
-                            <NonClickableIcon className={(generatedClasses.nonClickableIcon)}>{icon}</NonClickableIcon>
+                            <NonClickableIcon className={generatedClasses.nonClickableIcon}>{icon}</NonClickableIcon>
                         )}
                     </Navigation>
                 )}

--- a/components/src/core/Drawer/DrawerHeader/DrawerHeader.tsx
+++ b/components/src/core/Drawer/DrawerHeader/DrawerHeader.tsx
@@ -246,7 +246,7 @@ const DrawerHeaderRender: React.ForwardRefRenderFunction<unknown, DrawerHeaderPr
                 {getBackgroundImage()}
                 {icon && (
                     <Navigation
-                        className={clsx(generatedClasses.navigation, classes.navigation, {
+                        className={clsx(generatedClasses.navigation, {
                             [generatedClasses.railIcon]: variant === 'rail' && !condensed,
                             [generatedClasses.nonClickable]: variant === 'rail' && !condensed && !onIconClick,
                         })}

--- a/components/src/core/Drawer/DrawerHeader/DrawerHeader.tsx
+++ b/components/src/core/Drawer/DrawerHeader/DrawerHeader.tsx
@@ -195,11 +195,11 @@ const DrawerHeaderRender: React.ForwardRefRenderFunction<unknown, DrawerHeaderPr
     const getHeaderContent = useCallback(
         (): ReactNode =>
             titleContent || (
-                <Content className={cx(defaultClasses.content, classes.content)}>
+                <Content className={cx(defaultClasses.content)}>
                     <Title
                         noWrap
                         variant={'h6'}
-                        className={cx(defaultClasses.title, classes.title)}
+                        className={cx(defaultClasses.title)}
                         data-testid={'blui-drawer-header-title'}
                     >
                         {title}
@@ -209,7 +209,7 @@ const DrawerHeaderRender: React.ForwardRefRenderFunction<unknown, DrawerHeaderPr
                         <Subtitle
                             noWrap
                             variant={'body2'}
-                            className={cx(defaultClasses.subtitle, classes.subtitle)}
+                            className={cx(defaultClasses.subtitle)}
                             data-testid={'blui-drawer-header-subtitle'}
                         >
                             {subtitle}
@@ -224,7 +224,7 @@ const DrawerHeaderRender: React.ForwardRefRenderFunction<unknown, DrawerHeaderPr
         (): JSX.Element | null =>
             backgroundImage ? (
                 <Background
-                    className={cx(defaultClasses.background, classes.background)}
+                    className={cx(defaultClasses.background)}
                     backgroundImage={backgroundImage}
                     backgroundOpacity={backgroundOpacity}
                 />
@@ -237,7 +237,7 @@ const DrawerHeaderRender: React.ForwardRefRenderFunction<unknown, DrawerHeaderPr
             <Root
                 ref={ref}
                 data-testid={'blui-drawer-header'}
-                className={cx(defaultClasses.root, classes.root)}
+                className={cx(defaultClasses.root)}
                 backgroundColor={backgroundColor}
                 fontColor={fontColor}
                 disableGutters={disableGutters}
@@ -266,9 +266,7 @@ const DrawerHeaderRender: React.ForwardRefRenderFunction<unknown, DrawerHeaderPr
                             </IconButton>
                         )}
                         {!onIconClick && (
-                            <NonClickableIcon className={cx(defaultClasses.nonClickableIcon, classes.nonClickableIcon)}>
-                                {icon}
-                            </NonClickableIcon>
+                            <NonClickableIcon className={cx(defaultClasses.nonClickableIcon)}>{icon}</NonClickableIcon>
                         )}
                     </Navigation>
                 )}

--- a/components/src/core/Drawer/DrawerHeader/DrawerHeader.tsx
+++ b/components/src/core/Drawer/DrawerHeader/DrawerHeader.tsx
@@ -10,7 +10,6 @@ import drawerHeaderClasses, {
     DrawerHeaderClassKey,
     getDrawerHeaderUtilityClass,
 } from './DrawerHeaderClasses';
-import { cx } from '@emotion/css';
 import clsx from 'clsx';
 import { styled, SxProps, Theme } from '@mui/material/styles';
 import Box from '@mui/material/Box';
@@ -169,7 +168,7 @@ const DrawerHeaderRender: React.ForwardRefRenderFunction<unknown, DrawerHeaderPr
     props: DrawerHeaderProps,
     ref: any
 ) => {
-    const defaultClasses = useUtilityClasses(props);
+    const generatedClasses = useUtilityClasses(props);
     const {
         backgroundImage,
         classes,
@@ -195,11 +194,11 @@ const DrawerHeaderRender: React.ForwardRefRenderFunction<unknown, DrawerHeaderPr
     const getHeaderContent = useCallback(
         (): ReactNode =>
             titleContent || (
-                <Content className={cx(defaultClasses.content)}>
+                <Content className={(generatedClasses.content)}>
                     <Title
                         noWrap
                         variant={'h6'}
-                        className={cx(defaultClasses.title)}
+                        className={(generatedClasses.title)}
                         data-testid={'blui-drawer-header-title'}
                     >
                         {title}
@@ -209,7 +208,7 @@ const DrawerHeaderRender: React.ForwardRefRenderFunction<unknown, DrawerHeaderPr
                         <Subtitle
                             noWrap
                             variant={'body2'}
-                            className={cx(defaultClasses.subtitle)}
+                            className={(generatedClasses.subtitle)}
                             data-testid={'blui-drawer-header-subtitle'}
                         >
                             {subtitle}
@@ -217,19 +216,19 @@ const DrawerHeaderRender: React.ForwardRefRenderFunction<unknown, DrawerHeaderPr
                     )}
                 </Content>
             ),
-        [defaultClasses, classes, title, subtitle, titleContent]
+        [generatedClasses, classes, title, subtitle, titleContent]
     );
 
     const getBackgroundImage = useCallback(
         (): JSX.Element | null =>
             backgroundImage ? (
                 <Background
-                    className={cx(defaultClasses.background)}
+                    className={(generatedClasses.background)}
                     backgroundImage={backgroundImage}
                     backgroundOpacity={backgroundOpacity}
                 />
             ) : null,
-        [backgroundImage, defaultClasses, classes]
+        [backgroundImage, generatedClasses, classes]
     );
 
     return (
@@ -237,7 +236,7 @@ const DrawerHeaderRender: React.ForwardRefRenderFunction<unknown, DrawerHeaderPr
             <Root
                 ref={ref}
                 data-testid={'blui-drawer-header'}
-                className={cx(defaultClasses.root)}
+                className={(generatedClasses.root)}
                 backgroundColor={backgroundColor}
                 fontColor={fontColor}
                 disableGutters={disableGutters}
@@ -247,10 +246,10 @@ const DrawerHeaderRender: React.ForwardRefRenderFunction<unknown, DrawerHeaderPr
                 {getBackgroundImage()}
                 {icon && (
                     <Navigation
-                        className={clsx(defaultClasses.navigation, classes.navigation, {
-                            [defaultClasses.railIcon]: variant === 'rail' && !condensed,
+                        className={clsx(generatedClasses.navigation, classes.navigation, {
+                            [generatedClasses.railIcon]: variant === 'rail' && !condensed,
                             [classes.railIcon]: variant === 'rail' && !condensed && classes.railIcon,
-                            [defaultClasses.nonClickable]: variant === 'rail' && !condensed && !onIconClick,
+                            [generatedClasses.nonClickable]: variant === 'rail' && !condensed && !onIconClick,
                         })}
                     >
                         {onIconClick && (
@@ -266,7 +265,7 @@ const DrawerHeaderRender: React.ForwardRefRenderFunction<unknown, DrawerHeaderPr
                             </IconButton>
                         )}
                         {!onIconClick && (
-                            <NonClickableIcon className={cx(defaultClasses.nonClickableIcon)}>{icon}</NonClickableIcon>
+                            <NonClickableIcon className={(generatedClasses.nonClickableIcon)}>{icon}</NonClickableIcon>
                         )}
                     </Navigation>
                 )}

--- a/components/src/core/Drawer/DrawerHeader/DrawerHeader.tsx
+++ b/components/src/core/Drawer/DrawerHeader/DrawerHeader.tsx
@@ -216,7 +216,7 @@ const DrawerHeaderRender: React.ForwardRefRenderFunction<unknown, DrawerHeaderPr
                     )}
                 </Content>
             ),
-        [generatedClasses, classes, title, subtitle, titleContent]
+        [generatedClasses, title, subtitle, titleContent]
     );
 
     const getBackgroundImage = useCallback(
@@ -228,7 +228,7 @@ const DrawerHeaderRender: React.ForwardRefRenderFunction<unknown, DrawerHeaderPr
                     backgroundOpacity={backgroundOpacity}
                 />
             ) : null,
-        [backgroundImage, generatedClasses, classes]
+        [backgroundImage, generatedClasses]
     );
 
     return (

--- a/components/src/core/Drawer/DrawerNavGroup/DrawerNavGroup.tsx
+++ b/components/src/core/Drawer/DrawerNavGroup/DrawerNavGroup.tsx
@@ -116,6 +116,7 @@ const DrawerNavGroupRender: React.ForwardRefRenderFunction<unknown, DrawerNavGro
     const {
         // Nav Group Props
         children,
+        classes,
         className: userClassName,
         items = [],
         title,

--- a/components/src/core/Drawer/DrawerNavGroup/DrawerNavGroup.tsx
+++ b/components/src/core/Drawer/DrawerNavGroup/DrawerNavGroup.tsx
@@ -248,13 +248,13 @@ const DrawerNavGroupRender: React.ForwardRefRenderFunction<unknown, DrawerNavGro
                 subheader={
                     variant !== 'rail' && (
                         <SubHeader
-                            className={(generatedClasses.subheader)}
+                            className={generatedClasses.subheader}
                             style={{
                                 color: drawerOpen ? titleColor : 'transparent',
                             }}
                         >
                             {title && (
-                                <Title noWrap variant={'overline'} className={(generatedClasses.title)}>
+                                <Title noWrap variant={'overline'} className={generatedClasses.title}>
                                     {title}
                                 </Title>
                             )}

--- a/components/src/core/Drawer/DrawerNavGroup/DrawerNavGroup.tsx
+++ b/components/src/core/Drawer/DrawerNavGroup/DrawerNavGroup.tsx
@@ -111,7 +111,7 @@ const DrawerNavGroupRender: React.ForwardRefRenderFunction<unknown, DrawerNavGro
     props: DrawerNavGroupProps,
     ref: any
 ) => {
-    const defaultClasses = useUtilityClasses(props);
+    const generatedClasses = useUtilityClasses(props);
     const theme = useTheme();
     const {
         // Nav Group Props
@@ -244,17 +244,17 @@ const DrawerNavGroupRender: React.ForwardRefRenderFunction<unknown, DrawerNavGro
             <Root
                 ref={ref}
                 data-testid={'blui-drawer-nav-group'}
-                className={cx(defaultClasses.root, userClassName)}
+                className={cx(generatedClasses.root, userClassName)}
                 subheader={
                     variant !== 'rail' && (
                         <SubHeader
-                            className={cx(defaultClasses.subheader)}
+                            className={(generatedClasses.subheader)}
                             style={{
                                 color: drawerOpen ? titleColor : 'transparent',
                             }}
                         >
                             {title && (
-                                <Title noWrap variant={'overline'} className={cx(defaultClasses.title)}>
+                                <Title noWrap variant={'overline'} className={(generatedClasses.title)}>
                                     {title}
                                 </Title>
                             )}

--- a/components/src/core/Drawer/DrawerNavGroup/DrawerNavGroup.tsx
+++ b/components/src/core/Drawer/DrawerNavGroup/DrawerNavGroup.tsx
@@ -116,7 +116,6 @@ const DrawerNavGroupRender: React.ForwardRefRenderFunction<unknown, DrawerNavGro
     const {
         // Nav Group Props
         children,
-        classes,
         className: userClassName,
         items = [],
         title,
@@ -245,17 +244,17 @@ const DrawerNavGroupRender: React.ForwardRefRenderFunction<unknown, DrawerNavGro
             <Root
                 ref={ref}
                 data-testid={'blui-drawer-nav-group'}
-                className={cx(defaultClasses.root, classes.root, userClassName)}
+                className={cx(defaultClasses.root, userClassName)}
                 subheader={
                     variant !== 'rail' && (
                         <SubHeader
-                            className={cx(defaultClasses.subheader, classes.subheader)}
+                            className={cx(defaultClasses.subheader)}
                             style={{
                                 color: drawerOpen ? titleColor : 'transparent',
                             }}
                         >
                             {title && (
-                                <Title noWrap variant={'overline'} className={cx(defaultClasses.title, classes.title)}>
+                                <Title noWrap variant={'overline'} className={cx(defaultClasses.title)}>
                                     {title}
                                 </Title>
                             )}

--- a/components/src/core/Drawer/DrawerNavGroup/DrawerNavGroup.tsx
+++ b/components/src/core/Drawer/DrawerNavGroup/DrawerNavGroup.tsx
@@ -152,7 +152,8 @@ const DrawerNavGroupRender: React.ForwardRefRenderFunction<unknown, DrawerNavGro
     useEffect(() => {
         if (!findID({ items: props.items, children: props.children } as DrawerNavItemProps, activeItem))
             setActiveHierarchyItems([]);
-    }, [activeItem, props.children, props.items]);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [activeItem]);
 
     const getChildren = useCallback(
         (): JSX.Element[] =>

--- a/components/src/core/Drawer/DrawerNavGroup/DrawerNavGroup.tsx
+++ b/components/src/core/Drawer/DrawerNavGroup/DrawerNavGroup.tsx
@@ -152,7 +152,7 @@ const DrawerNavGroupRender: React.ForwardRefRenderFunction<unknown, DrawerNavGro
     useEffect(() => {
         if (!findID({ items: props.items, children: props.children } as DrawerNavItemProps, activeItem))
             setActiveHierarchyItems([]);
-    }, [activeItem]);
+    }, [activeItem, props.children, props.items]);
 
     const getChildren = useCallback(
         (): JSX.Element[] =>

--- a/components/src/core/Drawer/DrawerNavItem/DrawerNavItem.tsx
+++ b/components/src/core/Drawer/DrawerNavItem/DrawerNavItem.tsx
@@ -227,7 +227,6 @@ const DrawerNavItemRender: React.ForwardRefRenderFunction<HTMLElement, DrawerNav
         chevronColor,
         children,
         className,
-        classes = {},
         collapseIcon,
         depth = 0,
         disableActiveItemParentStyles = false,

--- a/components/src/core/Drawer/DrawerNavItem/DrawerNavItem.tsx
+++ b/components/src/core/Drawer/DrawerNavItem/DrawerNavItem.tsx
@@ -283,7 +283,7 @@ const DrawerNavItemRender: React.ForwardRefRenderFunction<HTMLElement, DrawerNav
             ? {
                   TouchRippleProps: {
                       classes: {
-                          child: cx(defaultClasses.ripple, classes.ripple),
+                          child: cx(defaultClasses.ripple),
                       },
                   },
               }
@@ -316,7 +316,7 @@ const DrawerNavItemRender: React.ForwardRefRenderFunction<HTMLElement, DrawerNav
                         e.stopPropagation();
                     }
                 }}
-                className={cx(defaultClasses.expandIcon, classes.expandIcon)}
+                className={cx(defaultClasses.expandIcon)}
                 collapseIcon={collapseIcon}
                 expanded={expanded}
             >
@@ -416,18 +416,15 @@ const DrawerNavItemRender: React.ForwardRefRenderFunction<HTMLElement, DrawerNav
 
     // Combine the classes to pass down the the InfoListItem
     const infoListItemClasses = {
-        root: ripple && hasAction ? undefined : cx(defaultClasses.infoListItemRoot, classes.infoListItemRoot),
-        listItemButtonRoot:
-            ripple && hasAction ? cx(defaultClasses.infoListItemRoot, classes.infoListItemRoot) : undefined,
+        root: ripple && hasAction ? undefined : cx(defaultClasses.infoListItemRoot),
+        listItemButtonRoot: ripple && hasAction ? cx(defaultClasses.infoListItemRoot) : undefined,
         title: cx(
             defaultClasses.title,
-            classes.title,
             active || (!disableActiveItemParentStyles && isInActiveTree) ? defaultClasses.titleActive : undefined,
             (active || (!disableActiveItemParentStyles && isInActiveTree)) && classes.titleActive
                 ? classes.titleActive
                 : undefined,
-            depth > 0 ? defaultClasses.nestedTitle : undefined,
-            depth > 0 && classes.nestedTitle ? classes.nestedTitle : undefined
+            depth > 0 ? defaultClasses.nestedTitle : undefined
         ),
     };
 
@@ -437,7 +434,7 @@ const DrawerNavItemRender: React.ForwardRefRenderFunction<HTMLElement, DrawerNav
                 <Root
                     ref={ref}
                     style={{ ...style, position: 'relative' }}
-                    className={cx(defaultClasses.root, className, classes.root)}
+                    className={cx(defaultClasses.root, className)}
                     depth={depth}
                     nestedBackgroundColor={nestedBackgroundColor}
                     backgroundColor={backgroundColor}
@@ -445,7 +442,7 @@ const DrawerNavItemRender: React.ForwardRefRenderFunction<HTMLElement, DrawerNav
                 >
                     {active && (
                         <ActiveItem
-                            className={cx(defaultClasses.active, classes.active)}
+                            className={cx(defaultClasses.active)}
                             style={{ backgroundColor: activeItemBackgroundColor }}
                             activeItemBackgroundShape={activeItemBackgroundShape}
                         />
@@ -493,7 +490,7 @@ const DrawerNavItemRender: React.ForwardRefRenderFunction<HTMLElement, DrawerNav
             {((items && items.length > 0) || Boolean(children)) && (
                 <Collapse in={expanded && drawerOpen !== false} key={`${itemTitle}_group_${depth}`}>
                     <NestedListGroup
-                        className={cx(defaultClasses.nestedListGroup, classes.nestedListGroup)}
+                        className={cx(defaultClasses.nestedListGroup)}
                         nestedBackgroundColor={nestedBackgroundColor}
                     >
                         {items &&

--- a/components/src/core/Drawer/DrawerNavItem/DrawerNavItem.tsx
+++ b/components/src/core/Drawer/DrawerNavItem/DrawerNavItem.tsx
@@ -283,7 +283,7 @@ const DrawerNavItemRender: React.ForwardRefRenderFunction<HTMLElement, DrawerNav
             ? {
                   TouchRippleProps: {
                       classes: {
-                          child: (generatedClasses.ripple),
+                          child: generatedClasses.ripple,
                       },
                   },
               }
@@ -316,7 +316,7 @@ const DrawerNavItemRender: React.ForwardRefRenderFunction<HTMLElement, DrawerNav
                         e.stopPropagation();
                     }
                 }}
-                className={(generatedClasses.expandIcon)}
+                className={generatedClasses.expandIcon}
                 collapseIcon={collapseIcon}
                 expanded={expanded}
             >
@@ -416,14 +416,11 @@ const DrawerNavItemRender: React.ForwardRefRenderFunction<HTMLElement, DrawerNav
 
     // Combine the classes to pass down the the InfoListItem
     const infoListItemClasses = {
-        root: ripple && hasAction ? undefined : (generatedClasses.infoListItemRoot),
-        listItemButtonRoot: ripple && hasAction ? (generatedClasses.infoListItemRoot) : undefined,
+        root: ripple && hasAction ? undefined : generatedClasses.infoListItemRoot,
+        listItemButtonRoot: ripple && hasAction ? generatedClasses.infoListItemRoot : undefined,
         title: cx(
             generatedClasses.title,
             active || (!disableActiveItemParentStyles && isInActiveTree) ? generatedClasses.titleActive : undefined,
-            (active || (!disableActiveItemParentStyles && isInActiveTree)) && classes.titleActive
-                ? classes.titleActive
-                : undefined,
             depth > 0 ? generatedClasses.nestedTitle : undefined
         ),
     };
@@ -442,7 +439,7 @@ const DrawerNavItemRender: React.ForwardRefRenderFunction<HTMLElement, DrawerNav
                 >
                     {active && (
                         <ActiveItem
-                            className={(generatedClasses.active)}
+                            className={generatedClasses.active}
                             style={{ backgroundColor: activeItemBackgroundColor }}
                             activeItemBackgroundShape={activeItemBackgroundShape}
                         />
@@ -490,7 +487,7 @@ const DrawerNavItemRender: React.ForwardRefRenderFunction<HTMLElement, DrawerNav
             {((items && items.length > 0) || Boolean(children)) && (
                 <Collapse in={expanded && drawerOpen !== false} key={`${itemTitle}_group_${depth}`}>
                     <NestedListGroup
-                        className={(generatedClasses.nestedListGroup)}
+                        className={generatedClasses.nestedListGroup}
                         nestedBackgroundColor={nestedBackgroundColor}
                     >
                         {items &&

--- a/components/src/core/Drawer/DrawerNavItem/DrawerNavItem.tsx
+++ b/components/src/core/Drawer/DrawerNavItem/DrawerNavItem.tsx
@@ -323,7 +323,7 @@ const DrawerNavItemRender: React.ForwardRefRenderFunction<HTMLElement, DrawerNav
                 {collapseIcon && expanded ? collapseIcon : expandIcon}
             </ActiveComponent>
         );
-    }, [items, children, classes, generatedClasses, collapseIcon, expanded, expandIcon]);
+    }, [items, children, generatedClasses, collapseIcon, expanded, expandIcon]);
     const actionComponent = getActionComponent();
 
     const getChildren = useCallback(

--- a/components/src/core/Drawer/DrawerNavItem/DrawerNavItem.tsx
+++ b/components/src/core/Drawer/DrawerNavItem/DrawerNavItem.tsx
@@ -266,7 +266,7 @@ const DrawerNavItemRender: React.ForwardRefRenderFunction<HTMLElement, DrawerNav
         if (isInActiveTree && !expanded) {
             setExpanded(true);
         }
-    }, [isInActiveTree]); // Only update if the active tree changes (not after manual expand/collapse action)
+    }, [expanded, isInActiveTree]); // Only update if the active tree changes (not after manual expand/collapse action)
 
     // If the active item changes
     useEffect(() => {
@@ -274,7 +274,7 @@ const DrawerNavItemRender: React.ForwardRefRenderFunction<HTMLElement, DrawerNav
             // notify the parent that it should now be in the active tree
             notifyActiveParent([itemID]);
         }
-    }, [activeItem, notifyActiveParent]);
+    }, [activeItem, itemID, previousActive, notifyActiveParent]);
 
     // Customize the color of the Touch Ripple
     const RippleProps =
@@ -300,7 +300,7 @@ const DrawerNavItemRender: React.ForwardRefRenderFunction<HTMLElement, DrawerNav
                 setExpanded(!expanded);
             }
         },
-        [onItemSelect, onClick, itemID, items, expanded, setExpanded]
+        [onItemSelect, onClick, itemID, items, expanded, setExpanded, children]
     );
 
     const getActionComponent = useCallback((): JSX.Element => {
@@ -398,17 +398,21 @@ const DrawerNavItemRender: React.ForwardRefRenderFunction<HTMLElement, DrawerNav
             backgroundColor,
             chevron,
             chevronColor,
-            collapseIcon,
+            depth,
             disableActiveItemParentStyles,
             divider,
-            expandIcon,
             hidePadding,
+            itemID,
             itemFontColor,
             itemIconColor,
             nestedBackgroundColor,
             nestedDivider,
             notifyActiveParent,
+            props.collapseIcon,
+            props.expandIcon,
             ripple,
+            style,
+            sx,
             children,
         ]
     );

--- a/components/src/core/Drawer/DrawerNavItem/DrawerNavItem.tsx
+++ b/components/src/core/Drawer/DrawerNavItem/DrawerNavItem.tsx
@@ -266,7 +266,8 @@ const DrawerNavItemRender: React.ForwardRefRenderFunction<HTMLElement, DrawerNav
         if (isInActiveTree && !expanded) {
             setExpanded(true);
         }
-    }, [expanded, isInActiveTree]); // Only update if the active tree changes (not after manual expand/collapse action)
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [isInActiveTree]); // Only update if the active tree changes (not after manual expand/collapse action)
 
     // If the active item changes
     useEffect(() => {

--- a/components/src/core/Drawer/DrawerNavItem/DrawerNavItem.tsx
+++ b/components/src/core/Drawer/DrawerNavItem/DrawerNavItem.tsx
@@ -190,7 +190,7 @@ const DrawerNavItemRender: React.ForwardRefRenderFunction<HTMLElement, DrawerNav
     ref: any
 ) => {
     const theme = useTheme();
-    const defaultClasses = useUtilityClasses(props);
+    const generatedClasses = useUtilityClasses(props);
     const { open: drawerOpen = true, activeItem, onItemSelect } = useDrawerContext();
     const { activeHierarchy } = useNavGroupContext();
     const previousActive = usePrevious(activeItem);
@@ -283,7 +283,7 @@ const DrawerNavItemRender: React.ForwardRefRenderFunction<HTMLElement, DrawerNav
             ? {
                   TouchRippleProps: {
                       classes: {
-                          child: cx(defaultClasses.ripple),
+                          child: (generatedClasses.ripple),
                       },
                   },
               }
@@ -316,14 +316,14 @@ const DrawerNavItemRender: React.ForwardRefRenderFunction<HTMLElement, DrawerNav
                         e.stopPropagation();
                     }
                 }}
-                className={cx(defaultClasses.expandIcon)}
+                className={(generatedClasses.expandIcon)}
                 collapseIcon={collapseIcon}
                 expanded={expanded}
             >
                 {collapseIcon && expanded ? collapseIcon : expandIcon}
             </ActiveComponent>
         );
-    }, [items, children, classes, defaultClasses, collapseIcon, expanded, expandIcon]);
+    }, [items, children, classes, generatedClasses, collapseIcon, expanded, expandIcon]);
     const actionComponent = getActionComponent();
 
     const getChildren = useCallback(
@@ -416,15 +416,15 @@ const DrawerNavItemRender: React.ForwardRefRenderFunction<HTMLElement, DrawerNav
 
     // Combine the classes to pass down the the InfoListItem
     const infoListItemClasses = {
-        root: ripple && hasAction ? undefined : cx(defaultClasses.infoListItemRoot),
-        listItemButtonRoot: ripple && hasAction ? cx(defaultClasses.infoListItemRoot) : undefined,
+        root: ripple && hasAction ? undefined : (generatedClasses.infoListItemRoot),
+        listItemButtonRoot: ripple && hasAction ? (generatedClasses.infoListItemRoot) : undefined,
         title: cx(
-            defaultClasses.title,
-            active || (!disableActiveItemParentStyles && isInActiveTree) ? defaultClasses.titleActive : undefined,
+            generatedClasses.title,
+            active || (!disableActiveItemParentStyles && isInActiveTree) ? generatedClasses.titleActive : undefined,
             (active || (!disableActiveItemParentStyles && isInActiveTree)) && classes.titleActive
                 ? classes.titleActive
                 : undefined,
-            depth > 0 ? defaultClasses.nestedTitle : undefined
+            depth > 0 ? generatedClasses.nestedTitle : undefined
         ),
     };
 
@@ -434,7 +434,7 @@ const DrawerNavItemRender: React.ForwardRefRenderFunction<HTMLElement, DrawerNav
                 <Root
                     ref={ref}
                     style={{ ...style, position: 'relative' }}
-                    className={cx(defaultClasses.root, className)}
+                    className={cx(generatedClasses.root, className)}
                     depth={depth}
                     nestedBackgroundColor={nestedBackgroundColor}
                     backgroundColor={backgroundColor}
@@ -442,7 +442,7 @@ const DrawerNavItemRender: React.ForwardRefRenderFunction<HTMLElement, DrawerNav
                 >
                     {active && (
                         <ActiveItem
-                            className={cx(defaultClasses.active)}
+                            className={(generatedClasses.active)}
                             style={{ backgroundColor: activeItemBackgroundColor }}
                             activeItemBackgroundShape={activeItemBackgroundShape}
                         />
@@ -490,7 +490,7 @@ const DrawerNavItemRender: React.ForwardRefRenderFunction<HTMLElement, DrawerNav
             {((items && items.length > 0) || Boolean(children)) && (
                 <Collapse in={expanded && drawerOpen !== false} key={`${itemTitle}_group_${depth}`}>
                     <NestedListGroup
-                        className={cx(defaultClasses.nestedListGroup)}
+                        className={(generatedClasses.nestedListGroup)}
                         nestedBackgroundColor={nestedBackgroundColor}
                     >
                         {items &&

--- a/components/src/core/Drawer/DrawerRailItem/DrawerRailItem.tsx
+++ b/components/src/core/Drawer/DrawerRailItem/DrawerRailItem.tsx
@@ -272,7 +272,7 @@ const DrawerRailItemRender: React.ForwardRefRenderFunction<unknown, DrawerRailIt
             ? {
                   TouchRippleProps: {
                       classes: {
-                          child: classes.ripple,
+                          child: generatedClasses.ripple,
                       },
                   },
               }
@@ -286,7 +286,8 @@ const DrawerRailItemRender: React.ForwardRefRenderFunction<unknown, DrawerRailIt
                 </Icon>
             );
         }
-    }, [generatedClasses.icon, icon, itemIconColor]);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [icon]);
 
     const onClickAction = useCallback(
         (e: React.MouseEvent<HTMLElement>): void => {

--- a/components/src/core/Drawer/DrawerRailItem/DrawerRailItem.tsx
+++ b/components/src/core/Drawer/DrawerRailItem/DrawerRailItem.tsx
@@ -280,7 +280,7 @@ const DrawerRailItemRender: React.ForwardRefRenderFunction<unknown, DrawerRailIt
     const getIcon = useCallback((): JSX.Element | undefined => {
         if (icon) {
             return (
-                <Icon className={'icon'} itemIconColor={itemIconColor}>
+                <Icon className={generatedClasses.icon} itemIconColor={itemIconColor}>
                     {icon}
                 </Icon>
             );

--- a/components/src/core/Drawer/DrawerRailItem/DrawerRailItem.tsx
+++ b/components/src/core/Drawer/DrawerRailItem/DrawerRailItem.tsx
@@ -272,16 +272,15 @@ const DrawerRailItemRender: React.ForwardRefRenderFunction<unknown, DrawerRailIt
             ? {
                   TouchRippleProps: {
                       classes: {
-                          child: cx(defaultClasses.ripple, classes.ripple),
+                          child: cx(defaultClasses.ripple),
                       },
                   },
               }
             : {};
 
     const combine = useCallback(
-        (drawerRailItemClassName: keyof DrawerRailItemClasses): string =>
-            cx(defaultClasses[drawerRailItemClassName], classes[drawerRailItemClassName]),
-        [defaultClasses, classes]
+        (drawerRailItemClassName: keyof DrawerRailItemClasses): string => cx(defaultClasses[drawerRailItemClassName]),
+        [defaultClasses]
     );
 
     const getIcon = useCallback((): JSX.Element | undefined => {
@@ -313,7 +312,6 @@ const DrawerRailItemRender: React.ForwardRefRenderFunction<unknown, DrawerRailIt
             {...directButtonBaseProps}
             className={cx(
                 defaultClasses.root,
-                classes.root,
                 condensed && classes.condensed ? classes.condensed : undefined,
                 className
             )}
@@ -349,7 +347,6 @@ const DrawerRailItemRender: React.ForwardRefRenderFunction<unknown, DrawerRailIt
                     variant={'caption'}
                     className={cx(
                         defaultClasses.title,
-                        classes.title,
                         active && classes.titleActive ? classes.titleActive : undefined
                     )}
                     itemFontColor={itemFontColor}

--- a/components/src/core/Drawer/DrawerRailItem/DrawerRailItem.tsx
+++ b/components/src/core/Drawer/DrawerRailItem/DrawerRailItem.tsx
@@ -347,7 +347,7 @@ const DrawerRailItemRender: React.ForwardRefRenderFunction<unknown, DrawerRailIt
                     variant={'caption'}
                     className={cx(
                         generatedClasses.title,
-                        active && classes.titleActive ? classes.titleActive : undefined
+                        active && generatedClasses.titleActive
                     )}
                     itemFontColor={itemFontColor}
                     active={active}

--- a/components/src/core/Drawer/DrawerRailItem/DrawerRailItem.tsx
+++ b/components/src/core/Drawer/DrawerRailItem/DrawerRailItem.tsx
@@ -272,7 +272,7 @@ const DrawerRailItemRender: React.ForwardRefRenderFunction<unknown, DrawerRailIt
             ? {
                   TouchRippleProps: {
                       classes: {
-                          child: generatedClasses.ripple,
+                          child: classes.ripple,
                       },
                   },
               }

--- a/components/src/core/Drawer/DrawerRailItem/DrawerRailItem.tsx
+++ b/components/src/core/Drawer/DrawerRailItem/DrawerRailItem.tsx
@@ -244,6 +244,7 @@ const DrawerRailItemRender: React.ForwardRefRenderFunction<unknown, DrawerRailIt
         /* eslint-enable @typescript-eslint/no-unused-vars */
         divider,
         ripple = true,
+        classes = {},
         className,
         condensed: itemCondensed,
         hidden,
@@ -285,7 +286,7 @@ const DrawerRailItemRender: React.ForwardRefRenderFunction<unknown, DrawerRailIt
                 </Icon>
             );
         }
-    }, [icon]);
+    }, [generatedClasses.icon, icon, itemIconColor]);
 
     const onClickAction = useCallback(
         (e: React.MouseEvent<HTMLElement>): void => {

--- a/components/src/core/Drawer/DrawerRailItem/DrawerRailItem.tsx
+++ b/components/src/core/Drawer/DrawerRailItem/DrawerRailItem.tsx
@@ -322,10 +322,16 @@ const DrawerRailItemRender: React.ForwardRefRenderFunction<unknown, DrawerRailIt
             {...RippleProps}
         >
             {/* Active Item Highlight */}
-            {active && <ActiveItem className={generatedClasses.active} activeItemBackgroundColor={activeItemBackgroundColor} />}
+            {active && (
+                <ActiveItem className={generatedClasses.active} activeItemBackgroundColor={activeItemBackgroundColor} />
+            )}
             {/* Status Color Stripe */}
             {statusColor !== undefined && statusColor !== '' && (
-                <StatusStripe className={generatedClasses.statusStripe} data-testid={'blui-status-stripe'} statusColor={statusColor} />
+                <StatusStripe
+                    className={generatedClasses.statusStripe}
+                    data-testid={'blui-status-stripe'}
+                    statusColor={statusColor}
+                />
             )}
             {/* Icon */}
             {getIcon()}

--- a/components/src/core/Drawer/DrawerRailItem/DrawerRailItem.tsx
+++ b/components/src/core/Drawer/DrawerRailItem/DrawerRailItem.tsx
@@ -322,7 +322,7 @@ const DrawerRailItemRender: React.ForwardRefRenderFunction<unknown, DrawerRailIt
             {...RippleProps}
         >
             {/* Active Item Highlight */}
-            {active && <ActiveItem className={'active'} activeItemBackgroundColor={activeItemBackgroundColor} />}
+            {active && <ActiveItem className={generatedClasses.active} activeItemBackgroundColor={activeItemBackgroundColor} />}
             {/* Status Color Stripe */}
             {statusColor !== undefined && statusColor !== '' && (
                 <StatusStripe className={'statusStripe'} data-testid={'blui-status-stripe'} statusColor={statusColor} />

--- a/components/src/core/Drawer/DrawerRailItem/DrawerRailItem.tsx
+++ b/components/src/core/Drawer/DrawerRailItem/DrawerRailItem.tsx
@@ -341,7 +341,7 @@ const DrawerRailItemRender: React.ForwardRefRenderFunction<unknown, DrawerRailIt
                 </Title>
             )}
             {/* Divider */}
-            {divider && <DrawerRailItemDivider className={'divider'} />}
+            {divider && <DrawerRailItemDivider className={generatedClasses.divider} />}
         </Root>
     );
 

--- a/components/src/core/Drawer/DrawerRailItem/DrawerRailItem.tsx
+++ b/components/src/core/Drawer/DrawerRailItem/DrawerRailItem.tsx
@@ -244,7 +244,6 @@ const DrawerRailItemRender: React.ForwardRefRenderFunction<unknown, DrawerRailIt
         /* eslint-enable @typescript-eslint/no-unused-vars */
         divider,
         ripple = true,
-        classes = {},
         className,
         condensed: itemCondensed,
         hidden,
@@ -272,7 +271,7 @@ const DrawerRailItemRender: React.ForwardRefRenderFunction<unknown, DrawerRailIt
             ? {
                   TouchRippleProps: {
                       classes: {
-                          child: classes.ripple,
+                          child: generatedClasses.ripple,
                       },
                   },
               }

--- a/components/src/core/Drawer/DrawerRailItem/DrawerRailItem.tsx
+++ b/components/src/core/Drawer/DrawerRailItem/DrawerRailItem.tsx
@@ -278,20 +278,15 @@ const DrawerRailItemRender: React.ForwardRefRenderFunction<unknown, DrawerRailIt
               }
             : {};
 
-    const combine = useCallback(
-        (drawerRailItemClassName: keyof DrawerRailItemClasses): string => cx(generatedClasses[drawerRailItemClassName]),
-        [generatedClasses]
-    );
-
     const getIcon = useCallback((): JSX.Element | undefined => {
         if (icon) {
             return (
-                <Icon className={combine('icon')} itemIconColor={itemIconColor}>
+                <Icon className={'icon'} itemIconColor={itemIconColor}>
                     {icon}
                 </Icon>
             );
         }
-    }, [icon, combine]);
+    }, [icon]);
 
     const onClickAction = useCallback(
         (e: React.MouseEvent<HTMLElement>): void => {
@@ -328,16 +323,10 @@ const DrawerRailItemRender: React.ForwardRefRenderFunction<unknown, DrawerRailIt
             {...RippleProps}
         >
             {/* Active Item Highlight */}
-            {active && (
-                <ActiveItem className={combine('active')} activeItemBackgroundColor={activeItemBackgroundColor} />
-            )}
+            {active && <ActiveItem className={'active'} activeItemBackgroundColor={activeItemBackgroundColor} />}
             {/* Status Color Stripe */}
             {statusColor !== undefined && statusColor !== '' && (
-                <StatusStripe
-                    className={combine('statusStripe')}
-                    data-testid={'blui-status-stripe'}
-                    statusColor={statusColor}
-                />
+                <StatusStripe className={'statusStripe'} data-testid={'blui-status-stripe'} statusColor={statusColor} />
             )}
             {/* Icon */}
             {getIcon()}
@@ -345,10 +334,7 @@ const DrawerRailItemRender: React.ForwardRefRenderFunction<unknown, DrawerRailIt
             {!condensed && (
                 <Title
                     variant={'caption'}
-                    className={cx(
-                        generatedClasses.title,
-                        active && generatedClasses.titleActive
-                    )}
+                    className={cx(generatedClasses.title, active && generatedClasses.titleActive)}
                     itemFontColor={itemFontColor}
                     active={active}
                 >
@@ -356,7 +342,7 @@ const DrawerRailItemRender: React.ForwardRefRenderFunction<unknown, DrawerRailIt
                 </Title>
             )}
             {/* Divider */}
-            {divider && <DrawerRailItemDivider className={combine('divider')} />}
+            {divider && <DrawerRailItemDivider className={'divider'} />}
         </Root>
     );
 

--- a/components/src/core/Drawer/DrawerRailItem/DrawerRailItem.tsx
+++ b/components/src/core/Drawer/DrawerRailItem/DrawerRailItem.tsx
@@ -244,7 +244,6 @@ const DrawerRailItemRender: React.ForwardRefRenderFunction<unknown, DrawerRailIt
         /* eslint-enable @typescript-eslint/no-unused-vars */
         divider,
         ripple = true,
-        classes = {},
         className,
         condensed: itemCondensed,
         hidden,

--- a/components/src/core/Drawer/DrawerRailItem/DrawerRailItem.tsx
+++ b/components/src/core/Drawer/DrawerRailItem/DrawerRailItem.tsx
@@ -325,7 +325,7 @@ const DrawerRailItemRender: React.ForwardRefRenderFunction<unknown, DrawerRailIt
             {active && <ActiveItem className={generatedClasses.active} activeItemBackgroundColor={activeItemBackgroundColor} />}
             {/* Status Color Stripe */}
             {statusColor !== undefined && statusColor !== '' && (
-                <StatusStripe className={'statusStripe'} data-testid={'blui-status-stripe'} statusColor={statusColor} />
+                <StatusStripe className={generatedClasses.statusStripe} data-testid={'blui-status-stripe'} statusColor={statusColor} />
             )}
             {/* Icon */}
             {getIcon()}

--- a/components/src/core/Drawer/DrawerRailItem/DrawerRailItem.tsx
+++ b/components/src/core/Drawer/DrawerRailItem/DrawerRailItem.tsx
@@ -272,7 +272,7 @@ const DrawerRailItemRender: React.ForwardRefRenderFunction<unknown, DrawerRailIt
             ? {
                   TouchRippleProps: {
                       classes: {
-                          child: (generatedClasses.ripple),
+                          child: generatedClasses.ripple,
                       },
                   },
               }
@@ -312,7 +312,7 @@ const DrawerRailItemRender: React.ForwardRefRenderFunction<unknown, DrawerRailIt
             {...directButtonBaseProps}
             className={cx(
                 generatedClasses.root,
-                condensed && classes.condensed ? classes.condensed : undefined,
+                condensed && generatedClasses.condensed ? generatedClasses.condensed : undefined,
                 className
             )}
             statusColor={statusColor}

--- a/components/src/core/Drawer/DrawerRailItem/DrawerRailItem.tsx
+++ b/components/src/core/Drawer/DrawerRailItem/DrawerRailItem.tsx
@@ -263,7 +263,7 @@ const DrawerRailItemRender: React.ForwardRefRenderFunction<unknown, DrawerRailIt
     const { activeItem, onItemSelect, condensed: drawerCondensed = false } = useDrawerContext();
     const active = activeItem === itemID;
     const condensed = itemCondensed !== undefined ? itemCondensed : drawerCondensed;
-    const defaultClasses = useUtilityClasses(props);
+    const generatedClasses = useUtilityClasses(props);
     const hasAction = Boolean(onClick || onItemSelect);
 
     // Customize the color of the Touch Ripple
@@ -272,15 +272,15 @@ const DrawerRailItemRender: React.ForwardRefRenderFunction<unknown, DrawerRailIt
             ? {
                   TouchRippleProps: {
                       classes: {
-                          child: cx(defaultClasses.ripple),
+                          child: (generatedClasses.ripple),
                       },
                   },
               }
             : {};
 
     const combine = useCallback(
-        (drawerRailItemClassName: keyof DrawerRailItemClasses): string => cx(defaultClasses[drawerRailItemClassName]),
-        [defaultClasses]
+        (drawerRailItemClassName: keyof DrawerRailItemClasses): string => cx(generatedClasses[drawerRailItemClassName]),
+        [generatedClasses]
     );
 
     const getIcon = useCallback((): JSX.Element | undefined => {
@@ -311,7 +311,7 @@ const DrawerRailItemRender: React.ForwardRefRenderFunction<unknown, DrawerRailIt
             {...ButtonBaseProps}
             {...directButtonBaseProps}
             className={cx(
-                defaultClasses.root,
+                generatedClasses.root,
                 condensed && classes.condensed ? classes.condensed : undefined,
                 className
             )}
@@ -346,7 +346,7 @@ const DrawerRailItemRender: React.ForwardRefRenderFunction<unknown, DrawerRailIt
                 <Title
                     variant={'caption'}
                     className={cx(
-                        defaultClasses.title,
+                        generatedClasses.title,
                         active && classes.titleActive ? classes.titleActive : undefined
                     )}
                     itemFontColor={itemFontColor}

--- a/components/src/core/DrawerLayout/DrawerLayout.tsx
+++ b/components/src/core/DrawerLayout/DrawerLayout.tsx
@@ -92,7 +92,6 @@ const DrawerLayoutRender: React.ForwardRefRenderFunction<unknown, DrawerLayoutPr
                 ref={ref}
                 className={cx(
                     defaultClasses.root,
-                    classes.root,
                     {
                         [defaultClasses.expanded]: drawerOpen,
                         [classes.expanded]: drawerOpen,
@@ -101,8 +100,8 @@ const DrawerLayoutRender: React.ForwardRefRenderFunction<unknown, DrawerLayoutPr
                 )}
                 {...otherProps}
             >
-                <Drawer className={cx(defaultClasses.drawer, classes.drawer)}>{drawer}</Drawer>
-                <Content className={cx(defaultClasses.content, classes.content)} style={style}>
+                <Drawer className={cx(defaultClasses.drawer)}>{drawer}</Drawer>
+                <Content className={cx(defaultClasses.content)} style={style}>
                     {children}
                 </Content>
             </Root>

--- a/components/src/core/DrawerLayout/DrawerLayout.tsx
+++ b/components/src/core/DrawerLayout/DrawerLayout.tsx
@@ -75,7 +75,7 @@ const DrawerLayoutRender: React.ForwardRefRenderFunction<unknown, DrawerLayoutPr
     const theme = useTheme();
     const [padding, setPadding] = useState<number | string>(0);
     const [drawerOpen, setDrawerOpen] = useState(false);
-    const defaultClasses = useUtilityClasses(props);
+    const generatedClasses = useUtilityClasses(props);
 
     const style: CSSProperties = { paddingLeft: 0, paddingRight: 0 };
     style.paddingLeft = theme.direction === 'ltr' ? padding : 0;
@@ -91,17 +91,17 @@ const DrawerLayoutRender: React.ForwardRefRenderFunction<unknown, DrawerLayoutPr
             <Root
                 ref={ref}
                 className={cx(
-                    defaultClasses.root,
+                    generatedClasses.root,
                     {
-                        [defaultClasses.expanded]: drawerOpen,
+                        [generatedClasses.expanded]: drawerOpen,
                         [classes.expanded]: drawerOpen,
                     },
                     userClassName
                 )}
                 {...otherProps}
             >
-                <Drawer className={cx(defaultClasses.drawer)}>{drawer}</Drawer>
-                <Content className={cx(defaultClasses.content)} style={style}>
+                <Drawer className={(generatedClasses.drawer)}>{drawer}</Drawer>
+                <Content className={(generatedClasses.content)} style={style}>
                     {children}
                 </Content>
             </Root>

--- a/components/src/core/DrawerLayout/DrawerLayout.tsx
+++ b/components/src/core/DrawerLayout/DrawerLayout.tsx
@@ -94,14 +94,13 @@ const DrawerLayoutRender: React.ForwardRefRenderFunction<unknown, DrawerLayoutPr
                     generatedClasses.root,
                     {
                         [generatedClasses.expanded]: drawerOpen,
-                        [classes.expanded]: drawerOpen,
                     },
                     userClassName
                 )}
                 {...otherProps}
             >
-                <Drawer className={(generatedClasses.drawer)}>{drawer}</Drawer>
-                <Content className={(generatedClasses.content)} style={style}>
+                <Drawer className={generatedClasses.drawer}>{drawer}</Drawer>
+                <Content className={generatedClasses.content} style={style}>
                     {children}
                 </Content>
             </Root>

--- a/components/src/core/EmptyState/EmptyState.tsx
+++ b/components/src/core/EmptyState/EmptyState.tsx
@@ -86,10 +86,10 @@ const EmptyStateRender: React.ForwardRefRenderFunction<unknown, EmptyStateProps>
             data-testid={'blui-empty-state-root'}
             {...otherProps}
         >
-            {icon && <Icon className={(generatedClasses.icon)}>{icon}</Icon>}
+            {icon && <Icon className={generatedClasses.icon}>{icon}</Icon>}
             {title &&
                 (typeof title === 'string' ? (
-                    <Typography variant="h6" color="inherit" className={classes.title}>
+                    <Typography variant="h6" color="inherit" className={generatedClasses.title}>
                         {title}
                     </Typography>
                 ) : (
@@ -97,13 +97,13 @@ const EmptyStateRender: React.ForwardRefRenderFunction<unknown, EmptyStateProps>
                 ))}
             {description &&
                 (typeof description === 'string' ? (
-                    <Description variant="subtitle2" color={'textSecondary'} className={(generatedClasses.description)}>
+                    <Description variant="subtitle2" color={'textSecondary'} className={generatedClasses.description}>
                         {description}
                     </Description>
                 ) : (
                     description
                 ))}
-            {actions && <Actions className={(generatedClasses.actions)}>{actions}</Actions>}
+            {actions && <Actions className={generatedClasses.actions}>{actions}</Actions>}
         </Root>
     );
 };

--- a/components/src/core/EmptyState/EmptyState.tsx
+++ b/components/src/core/EmptyState/EmptyState.tsx
@@ -82,11 +82,11 @@ const EmptyStateRender: React.ForwardRefRenderFunction<unknown, EmptyStateProps>
     return (
         <Root
             ref={ref}
-            className={cx(defaultClasses.root, classes.root, userClassName)}
+            className={cx(defaultClasses.root, userClassName)}
             data-testid={'blui-empty-state-root'}
             {...otherProps}
         >
-            {icon && <Icon className={cx(defaultClasses.icon, classes.icon)}>{icon}</Icon>}
+            {icon && <Icon className={cx(defaultClasses.icon)}>{icon}</Icon>}
             {title &&
                 (typeof title === 'string' ? (
                     <Typography variant="h6" color="inherit" className={classes.title}>
@@ -97,17 +97,13 @@ const EmptyStateRender: React.ForwardRefRenderFunction<unknown, EmptyStateProps>
                 ))}
             {description &&
                 (typeof description === 'string' ? (
-                    <Description
-                        variant="subtitle2"
-                        color={'textSecondary'}
-                        className={cx(defaultClasses.description, classes.description)}
-                    >
+                    <Description variant="subtitle2" color={'textSecondary'} className={cx(defaultClasses.description)}>
                         {description}
                     </Description>
                 ) : (
                     description
                 ))}
-            {actions && <Actions className={cx(defaultClasses.actions, classes.actions)}>{actions}</Actions>}
+            {actions && <Actions className={cx(defaultClasses.actions)}>{actions}</Actions>}
         </Root>
     );
 };

--- a/components/src/core/EmptyState/EmptyState.tsx
+++ b/components/src/core/EmptyState/EmptyState.tsx
@@ -77,16 +77,16 @@ const EmptyStateRender: React.ForwardRefRenderFunction<unknown, EmptyStateProps>
     ref: any
 ) => {
     const { actions, classes, className: userClassName, description, icon, title, ...otherProps } = props;
-    const defaultClasses = useUtilityClasses(props);
+    const generatedClasses = useUtilityClasses(props);
 
     return (
         <Root
             ref={ref}
-            className={cx(defaultClasses.root, userClassName)}
+            className={cx(generatedClasses.root, userClassName)}
             data-testid={'blui-empty-state-root'}
             {...otherProps}
         >
-            {icon && <Icon className={cx(defaultClasses.icon)}>{icon}</Icon>}
+            {icon && <Icon className={(generatedClasses.icon)}>{icon}</Icon>}
             {title &&
                 (typeof title === 'string' ? (
                     <Typography variant="h6" color="inherit" className={classes.title}>
@@ -97,13 +97,13 @@ const EmptyStateRender: React.ForwardRefRenderFunction<unknown, EmptyStateProps>
                 ))}
             {description &&
                 (typeof description === 'string' ? (
-                    <Description variant="subtitle2" color={'textSecondary'} className={cx(defaultClasses.description)}>
+                    <Description variant="subtitle2" color={'textSecondary'} className={(generatedClasses.description)}>
                         {description}
                     </Description>
                 ) : (
                     description
                 ))}
-            {actions && <Actions className={cx(defaultClasses.actions)}>{actions}</Actions>}
+            {actions && <Actions className={(generatedClasses.actions)}>{actions}</Actions>}
         </Root>
     );
 };

--- a/components/src/core/Hero/Hero.tsx
+++ b/components/src/core/Hero/Hero.tsx
@@ -109,7 +109,7 @@ const Label = styled(
 }));
 
 const HeroRender: React.ForwardRefRenderFunction<unknown, HeroProps> = (props: HeroProps, ref: any) => {
-    const defaultClasses = useUtilityClasses(props);
+    const generatedClasses = useUtilityClasses(props);
     const {
         className: userClassName,
         icon,
@@ -126,20 +126,20 @@ const HeroRender: React.ForwardRefRenderFunction<unknown, HeroProps> = (props: H
     return (
         <Root
             ref={ref}
-            className={cx(defaultClasses.root, userClassName)}
+            className={cx(generatedClasses.root, userClassName)}
             data-testid={'blui-hero-root'}
             {...otherProps}
         >
-            <Icon className={cx(defaultClasses.icon)} iconSize={iconSize} iconBackgroundColor={iconBackgroundColor}>
+            <Icon className={(generatedClasses.icon)} iconSize={iconSize} iconBackgroundColor={iconBackgroundColor}>
                 {icon}
             </Icon>
-            <Values component={'span'} className={cx(defaultClasses.values)}>
+            <Values component={'span'} className={(generatedClasses.values)}>
                 {!props.children && ChannelValueProps?.value && (
                     <ChannelValue fontSize={ChannelValueProps?.fontSize} {...ChannelValueProps} />
                 )}
                 {props.children}
             </Values>
-            <Label variant={'body1'} color={'inherit'} className={cx(defaultClasses.label)}>
+            <Label variant={'body1'} color={'inherit'} className={(generatedClasses.label)}>
                 {label}
             </Label>
         </Root>

--- a/components/src/core/Hero/Hero.tsx
+++ b/components/src/core/Hero/Hero.tsx
@@ -130,16 +130,16 @@ const HeroRender: React.ForwardRefRenderFunction<unknown, HeroProps> = (props: H
             data-testid={'blui-hero-root'}
             {...otherProps}
         >
-            <Icon className={(generatedClasses.icon)} iconSize={iconSize} iconBackgroundColor={iconBackgroundColor}>
+            <Icon className={generatedClasses.icon} iconSize={iconSize} iconBackgroundColor={iconBackgroundColor}>
                 {icon}
             </Icon>
-            <Values component={'span'} className={(generatedClasses.values)}>
+            <Values component={'span'} className={generatedClasses.values}>
                 {!props.children && ChannelValueProps?.value && (
                     <ChannelValue fontSize={ChannelValueProps?.fontSize} {...ChannelValueProps} />
                 )}
                 {props.children}
             </Values>
-            <Label variant={'body1'} color={'inherit'} className={(generatedClasses.label)}>
+            <Label variant={'body1'} color={'inherit'} className={generatedClasses.label}>
                 {label}
             </Label>
         </Root>

--- a/components/src/core/Hero/Hero.tsx
+++ b/components/src/core/Hero/Hero.tsx
@@ -111,7 +111,6 @@ const Label = styled(
 const HeroRender: React.ForwardRefRenderFunction<unknown, HeroProps> = (props: HeroProps, ref: any) => {
     const defaultClasses = useUtilityClasses(props);
     const {
-        classes,
         className: userClassName,
         icon,
         label,
@@ -127,24 +126,20 @@ const HeroRender: React.ForwardRefRenderFunction<unknown, HeroProps> = (props: H
     return (
         <Root
             ref={ref}
-            className={cx(defaultClasses.root, classes.root, userClassName)}
+            className={cx(defaultClasses.root, userClassName)}
             data-testid={'blui-hero-root'}
             {...otherProps}
         >
-            <Icon
-                className={cx(defaultClasses.icon, classes.icon)}
-                iconSize={iconSize}
-                iconBackgroundColor={iconBackgroundColor}
-            >
+            <Icon className={cx(defaultClasses.icon)} iconSize={iconSize} iconBackgroundColor={iconBackgroundColor}>
                 {icon}
             </Icon>
-            <Values component={'span'} className={cx(defaultClasses.values, classes.values)}>
+            <Values component={'span'} className={cx(defaultClasses.values)}>
                 {!props.children && ChannelValueProps?.value && (
                     <ChannelValue fontSize={ChannelValueProps?.fontSize} {...ChannelValueProps} />
                 )}
                 {props.children}
             </Values>
-            <Label variant={'body1'} color={'inherit'} className={cx(defaultClasses.label, classes.label)}>
+            <Label variant={'body1'} color={'inherit'} className={cx(defaultClasses.label)}>
                 {label}
             </Label>
         </Root>

--- a/components/src/core/HeroBanner/HeroBanner.tsx
+++ b/components/src/core/HeroBanner/HeroBanner.tsx
@@ -40,14 +40,14 @@ const HeroBannerRender: React.ForwardRefRenderFunction<unknown, HeroBannerProps>
     ref: any
 ) => {
     const { className: userClassName, divider, limit, ...otherProps } = props;
-    const defaultClasses = useUtilityClasses(props);
+    const generatedClasses = useUtilityClasses(props);
     const isArray = Array.isArray(props.children);
     return (
         <>
             <Root
                 ref={ref}
                 data-testid={'blui-hero-banner-root'}
-                className={cx(defaultClasses.root, userClassName)}
+                className={cx(generatedClasses.root, userClassName)}
                 {...otherProps}
             >
                 {props.children &&

--- a/components/src/core/HeroBanner/HeroBanner.tsx
+++ b/components/src/core/HeroBanner/HeroBanner.tsx
@@ -39,7 +39,7 @@ const HeroBannerRender: React.ForwardRefRenderFunction<unknown, HeroBannerProps>
     props: HeroBannerProps,
     ref: any
 ) => {
-    const { classes, className: userClassName, divider, limit, ...otherProps } = props;
+    const { className: userClassName, divider, limit, ...otherProps } = props;
     const defaultClasses = useUtilityClasses(props);
     const isArray = Array.isArray(props.children);
     return (
@@ -47,7 +47,7 @@ const HeroBannerRender: React.ForwardRefRenderFunction<unknown, HeroBannerProps>
             <Root
                 ref={ref}
                 data-testid={'blui-hero-banner-root'}
-                className={cx(defaultClasses.root, classes.root, userClassName)}
+                className={cx(defaultClasses.root, userClassName)}
                 {...otherProps}
             >
                 {props.children &&

--- a/components/src/core/InfoListItem/InfoListItem.tsx
+++ b/components/src/core/InfoListItem/InfoListItem.tsx
@@ -128,6 +128,7 @@ const InfoListItemRender: React.ForwardRefRenderFunction<unknown, InfoListItemPr
     const {
         avatar,
         chevron,
+        classes,
         className: userClassName,
         divider,
         hidePadding,

--- a/components/src/core/InfoListItem/InfoListItem.tsx
+++ b/components/src/core/InfoListItem/InfoListItem.tsx
@@ -156,11 +156,6 @@ const InfoListItemRender: React.ForwardRefRenderFunction<unknown, InfoListItemPr
         ...otherListItemProps
     } = props;
 
-    const combine = useCallback(
-        (className: keyof InfoListItemClasses): string => cx(generatedClasses[className]),
-        [generatedClasses]
-    );
-
     const getIcon = useCallback((): JSX.Element | undefined => {
         if (icon) {
             return (
@@ -170,7 +165,7 @@ const InfoListItemRender: React.ForwardRefRenderFunction<unknown, InfoListItemPr
                         iconColor={iconColor}
                         avatar={avatar}
                         iconAlign={iconAlign}
-                        className={avatar ? combine('avatar') : combine('icon')}
+                        className={avatar ? 'avatar' : 'icon'}
                     >
                         {icon}
                     </Icon>
@@ -181,7 +176,7 @@ const InfoListItemRender: React.ForwardRefRenderFunction<unknown, InfoListItemPr
                 // a dummy component to maintain the padding
                 <ListItemAvatar style={{ minWidth: 'unset' }}>
                     <Icon
-                        className={combine('avatar')}
+                        className={'avatar'}
                         statusColor={statusColor}
                         iconColor={iconColor}
                         avatar={avatar}
@@ -190,34 +185,32 @@ const InfoListItemRender: React.ForwardRefRenderFunction<unknown, InfoListItemPr
                 </ListItemAvatar>
             );
         }
-    }, [icon, avatar, hidePadding, combine]);
+    }, [icon, avatar, hidePadding]);
 
     const getRightComponent = useCallback(
         (): JSX.Element | undefined => (
             <>
-                {rightComponent && (
-                    <RightComponent className={combine('rightComponent')}>{rightComponent}</RightComponent>
-                )}
+                {rightComponent && <RightComponent className={'rightComponent'}>{rightComponent}</RightComponent>}
                 {chevron && (
                     <InfoListItemChevron
                         chevronColor={chevronColor}
                         color={'inherit'}
                         role={'button'}
-                        className={combine('chevron')}
+                        className={'chevron'}
                     />
                 )}
             </>
         ),
-        [rightComponent, chevron, combine]
+        [rightComponent, chevron]
     );
 
     const getSeparator = useCallback(
         (): JSX.Element => (
-            <SubtitleSeparator className={combine('separator')} component="span">
+            <SubtitleSeparator className={'separator'} component="span">
                 {subtitleSeparator || '\u00B7'}
             </SubtitleSeparator>
         ),
-        [combine, subtitleSeparator]
+        [subtitleSeparator]
     );
 
     const getSubtitle = useCallback((): string | null => {
@@ -250,18 +243,14 @@ const InfoListItemRender: React.ForwardRefRenderFunction<unknown, InfoListItemPr
 
     const getInfoListItemContent = (): JSX.Element => (
         <>
-            <StatusStripe
-                statusColor={statusColor}
-                className={combine('statusStripe')}
-                data-testid={'blui-status-stripe'}
-            />
-            {divider && <InfoListItemDivider divider={divider} className={combine('divider')} />}
+            <StatusStripe statusColor={statusColor} className={'statusStripe'} data-testid={'blui-status-stripe'} />
+            {divider && <InfoListItemDivider divider={divider} className={'divider'} />}
             {(icon || !hidePadding) && getIcon()}
             {leftComponent}
             <InfoListItemText
                 primary={title}
                 leftComponent={leftComponent}
-                className={combine('listItemText')}
+                className={'listItemText'}
                 secondary={
                     subtitle || info ? (
                         <>
@@ -271,7 +260,7 @@ const InfoListItemRender: React.ForwardRefRenderFunction<unknown, InfoListItemPr
                                     component="div"
                                     fontColor={fontColor}
                                     noWrap={!wrapSubtitle}
-                                    className={combine('subtitle')}
+                                    className={'subtitle'}
                                 >
                                     {getSubtitle()}
                                 </Subtitle>
@@ -282,7 +271,7 @@ const InfoListItemRender: React.ForwardRefRenderFunction<unknown, InfoListItemPr
                                     component="div"
                                     fontColor={fontColor}
                                     noWrap={!wrapInfo}
-                                    className={combine('info')}
+                                    className={'info'}
                                 >
                                     {getInfo()}
                                 </Info>
@@ -297,7 +286,7 @@ const InfoListItemRender: React.ForwardRefRenderFunction<unknown, InfoListItemPr
                     lineHeight: 1.25,
                     display: 'block',
                     color: fontColor || 'inherit',
-                    className: combine('title'),
+                    className: 'title',
                     component: 'div',
                 }}
                 secondaryTypographyProps={{
@@ -319,12 +308,12 @@ const InfoListItemRender: React.ForwardRefRenderFunction<unknown, InfoListItemPr
             dense={props.dense}
             ripple={ripple}
             iconColor={iconColor}
-            className={cx(combine('root'), userClassName)}
+            className={cx('root', userClassName)}
             ref={ref}
             {...otherListItemProps}
         >
             {props.onClick && ripple ? (
-                <InfoListItemContentContainer className={combine('listItemButtonRoot')} focusRipple={ripple}>
+                <InfoListItemContentContainer className={'listItemButtonRoot'} focusRipple={ripple}>
                     {getInfoListItemContent()}
                 </InfoListItemContentContainer>
             ) : (

--- a/components/src/core/InfoListItem/InfoListItem.tsx
+++ b/components/src/core/InfoListItem/InfoListItem.tsx
@@ -244,7 +244,7 @@ const InfoListItemRender: React.ForwardRefRenderFunction<unknown, InfoListItemPr
 
     const getInfoListItemContent = (): JSX.Element => (
         <>
-            <StatusStripe statusColor={statusColor} className={'statusStripe'} data-testid={'blui-status-stripe'} />
+            <StatusStripe statusColor={statusColor} className={generatedClasses['statusStripe']} data-testid={'blui-status-stripe'} />
             {divider && <InfoListItemDivider divider={divider} className={'divider'} />}
             {(icon || !hidePadding) && getIcon()}
             {leftComponent}

--- a/components/src/core/InfoListItem/InfoListItem.tsx
+++ b/components/src/core/InfoListItem/InfoListItem.tsx
@@ -19,6 +19,7 @@ import {
     SubtitleSeparator,
 } from './InfoListItemStyledComponents';
 import { getInfoListItemUtilityClass, InfoListItemClassKey, InfoListItemClasses } from './InfoListItemClasses';
+import { cx } from '@emotion/css';
 
 const MAX_SUBTITLE_ELEMENTS = 6;
 
@@ -185,7 +186,7 @@ const InfoListItemRender: React.ForwardRefRenderFunction<unknown, InfoListItemPr
                 </ListItemAvatar>
             );
         }
-    }, [icon, avatar, hidePadding, generatedClasses]);
+    }, [avatar, icon, iconAlign, iconColor, statusColor, hidePadding, generatedClasses]);
 
     const getRightComponent = useCallback(
         (): JSX.Element | undefined => (
@@ -203,7 +204,7 @@ const InfoListItemRender: React.ForwardRefRenderFunction<unknown, InfoListItemPr
                 )}
             </>
         ),
-        [rightComponent, chevron, generatedClasses]
+        [rightComponent, chevron, chevronColor, generatedClasses]
     );
 
     const getSeparator = useCallback(
@@ -212,7 +213,7 @@ const InfoListItemRender: React.ForwardRefRenderFunction<unknown, InfoListItemPr
                 {subtitleSeparator || '\u00B7'}
             </SubtitleSeparator>
         ),
-        [subtitleSeparator]
+        [generatedClasses, subtitleSeparator]
     );
 
     const getSubtitle = useCallback((): string | null => {

--- a/components/src/core/InfoListItem/InfoListItem.tsx
+++ b/components/src/core/InfoListItem/InfoListItem.tsx
@@ -245,7 +245,7 @@ const InfoListItemRender: React.ForwardRefRenderFunction<unknown, InfoListItemPr
     const getInfoListItemContent = (): JSX.Element => (
         <>
             <StatusStripe statusColor={statusColor} className={generatedClasses['statusStripe']} data-testid={'blui-status-stripe'} />
-            {divider && <InfoListItemDivider divider={divider} className={'divider'} />}
+            {divider && <InfoListItemDivider divider={divider} className={generatedClasses['divider']} />}
             {(icon || !hidePadding) && getIcon()}
             {leftComponent}
             <InfoListItemText

--- a/components/src/core/InfoListItem/InfoListItem.tsx
+++ b/components/src/core/InfoListItem/InfoListItem.tsx
@@ -313,7 +313,7 @@ const InfoListItemRender: React.ForwardRefRenderFunction<unknown, InfoListItemPr
             dense={props.dense}
             ripple={ripple}
             iconColor={iconColor}
-            className={(generatedClasses.root, userClassName)}
+            className={cx(generatedClasses.root, userClassName)}
             ref={ref}
             {...otherListItemProps}
         >

--- a/components/src/core/InfoListItem/InfoListItem.tsx
+++ b/components/src/core/InfoListItem/InfoListItem.tsx
@@ -184,7 +184,7 @@ const InfoListItemRender: React.ForwardRefRenderFunction<unknown, InfoListItemPr
                 </ListItemAvatar>
             );
         }
-    }, [icon, avatar, hidePadding]);
+    }, [icon, avatar, hidePadding, generatedClasses]);
 
     const getRightComponent = useCallback(
         (): JSX.Element | undefined => (

--- a/components/src/core/InfoListItem/InfoListItem.tsx
+++ b/components/src/core/InfoListItem/InfoListItem.tsx
@@ -129,7 +129,6 @@ const InfoListItemRender: React.ForwardRefRenderFunction<unknown, InfoListItemPr
     const {
         avatar,
         chevron,
-        classes,
         className: userClassName,
         divider,
         hidePadding,
@@ -158,8 +157,8 @@ const InfoListItemRender: React.ForwardRefRenderFunction<unknown, InfoListItemPr
     } = props;
 
     const combine = useCallback(
-        (className: keyof InfoListItemClasses): string => cx(defaultClasses[className], classes[className]),
-        [defaultClasses, classes]
+        (className: keyof InfoListItemClasses): string => cx(defaultClasses[className]),
+        [defaultClasses]
     );
 
     const getIcon = useCallback((): JSX.Element | undefined => {

--- a/components/src/core/InfoListItem/InfoListItem.tsx
+++ b/components/src/core/InfoListItem/InfoListItem.tsx
@@ -2,7 +2,6 @@ import React, { ReactNode, useCallback } from 'react';
 import { ListItemProps } from '@mui/material/ListItem';
 import { ListItemButtonProps as MuiListItemButtonProps } from '@mui/material/ListItemButton';
 import ListItemAvatar from '@mui/material/ListItemAvatar';
-import { cx } from '@emotion/css';
 import { unstable_composeClasses as composeClasses } from '@mui/base';
 import { separate, withKeys } from '../utilities';
 import PropTypes from 'prop-types';
@@ -165,7 +164,7 @@ const InfoListItemRender: React.ForwardRefRenderFunction<unknown, InfoListItemPr
                         iconColor={iconColor}
                         avatar={avatar}
                         iconAlign={iconAlign}
-                        className={avatar ? 'avatar' : 'icon'}
+                        className={generatedClasses[avatar ? 'avatar' : 'icon']}
                     >
                         {icon}
                     </Icon>
@@ -176,7 +175,7 @@ const InfoListItemRender: React.ForwardRefRenderFunction<unknown, InfoListItemPr
                 // a dummy component to maintain the padding
                 <ListItemAvatar style={{ minWidth: 'unset' }}>
                     <Icon
-                        className={'avatar'}
+                        className={generatedClasses['avatar']}
                         statusColor={statusColor}
                         iconColor={iconColor}
                         avatar={avatar}
@@ -190,13 +189,15 @@ const InfoListItemRender: React.ForwardRefRenderFunction<unknown, InfoListItemPr
     const getRightComponent = useCallback(
         (): JSX.Element | undefined => (
             <>
-                {rightComponent && <RightComponent className={'rightComponent'}>{rightComponent}</RightComponent>}
+                {rightComponent && (
+                    <RightComponent className={generatedClasses['rightComponent']}>{rightComponent}</RightComponent>
+                )}
                 {chevron && (
                     <InfoListItemChevron
                         chevronColor={chevronColor}
                         color={'inherit'}
                         role={'button'}
-                        className={'chevron'}
+                        className={generatedClasses['chevron']}
                     />
                 )}
             </>
@@ -206,7 +207,7 @@ const InfoListItemRender: React.ForwardRefRenderFunction<unknown, InfoListItemPr
 
     const getSeparator = useCallback(
         (): JSX.Element => (
-            <SubtitleSeparator className={'separator'} component="span">
+            <SubtitleSeparator className={generatedClasses['separator']} component="span">
                 {subtitleSeparator || '\u00B7'}
             </SubtitleSeparator>
         ),
@@ -250,7 +251,7 @@ const InfoListItemRender: React.ForwardRefRenderFunction<unknown, InfoListItemPr
             <InfoListItemText
                 primary={title}
                 leftComponent={leftComponent}
-                className={'listItemText'}
+                className={generatedClasses.listItemText}
                 secondary={
                     subtitle || info ? (
                         <>
@@ -260,7 +261,7 @@ const InfoListItemRender: React.ForwardRefRenderFunction<unknown, InfoListItemPr
                                     component="div"
                                     fontColor={fontColor}
                                     noWrap={!wrapSubtitle}
-                                    className={'subtitle'}
+                                    className={generatedClasses.subtitle}
                                 >
                                     {getSubtitle()}
                                 </Subtitle>
@@ -271,7 +272,7 @@ const InfoListItemRender: React.ForwardRefRenderFunction<unknown, InfoListItemPr
                                     component="div"
                                     fontColor={fontColor}
                                     noWrap={!wrapInfo}
-                                    className={'info'}
+                                    className={generatedClasses.info}
                                 >
                                     {getInfo()}
                                 </Info>
@@ -286,7 +287,7 @@ const InfoListItemRender: React.ForwardRefRenderFunction<unknown, InfoListItemPr
                     lineHeight: 1.25,
                     display: 'block',
                     color: fontColor || 'inherit',
-                    className: 'title',
+                    generatedClasses: 'title',
                     component: 'div',
                 }}
                 secondaryTypographyProps={{
@@ -308,12 +309,12 @@ const InfoListItemRender: React.ForwardRefRenderFunction<unknown, InfoListItemPr
             dense={props.dense}
             ripple={ripple}
             iconColor={iconColor}
-            className={cx('root', userClassName)}
+            className={(generatedClasses.root, userClassName)}
             ref={ref}
             {...otherListItemProps}
         >
             {props.onClick && ripple ? (
-                <InfoListItemContentContainer className={'listItemButtonRoot'} focusRipple={ripple}>
+                <InfoListItemContentContainer className={generatedClasses.listItemButtonRoot} focusRipple={ripple}>
                     {getInfoListItemContent()}
                 </InfoListItemContentContainer>
             ) : (

--- a/components/src/core/InfoListItem/InfoListItem.tsx
+++ b/components/src/core/InfoListItem/InfoListItem.tsx
@@ -287,7 +287,7 @@ const InfoListItemRender: React.ForwardRefRenderFunction<unknown, InfoListItemPr
                     lineHeight: 1.25,
                     display: 'block',
                     color: fontColor || 'inherit',
-                    generatedClasses: 'title',
+                    className: generatedClasses['title'],
                     component: 'div',
                 }}
                 secondaryTypographyProps={{

--- a/components/src/core/InfoListItem/InfoListItem.tsx
+++ b/components/src/core/InfoListItem/InfoListItem.tsx
@@ -244,7 +244,11 @@ const InfoListItemRender: React.ForwardRefRenderFunction<unknown, InfoListItemPr
 
     const getInfoListItemContent = (): JSX.Element => (
         <>
-            <StatusStripe statusColor={statusColor} className={generatedClasses['statusStripe']} data-testid={'blui-status-stripe'} />
+            <StatusStripe
+                statusColor={statusColor}
+                className={generatedClasses['statusStripe']}
+                data-testid={'blui-status-stripe'}
+            />
             {divider && <InfoListItemDivider divider={divider} className={generatedClasses['divider']} />}
             {(icon || !hidePadding) && getIcon()}
             {leftComponent}

--- a/components/src/core/InfoListItem/InfoListItem.tsx
+++ b/components/src/core/InfoListItem/InfoListItem.tsx
@@ -202,7 +202,7 @@ const InfoListItemRender: React.ForwardRefRenderFunction<unknown, InfoListItemPr
                 )}
             </>
         ),
-        [rightComponent, chevron]
+        [rightComponent, chevron, generatedClasses]
     );
 
     const getSeparator = useCallback(

--- a/components/src/core/InfoListItem/InfoListItem.tsx
+++ b/components/src/core/InfoListItem/InfoListItem.tsx
@@ -125,7 +125,7 @@ const InfoListItemRender: React.ForwardRefRenderFunction<unknown, InfoListItemPr
     props: InfoListItemProps,
     ref: any
 ) => {
-    const defaultClasses = useUtilityClasses(props);
+    const generatedClasses = useUtilityClasses(props);
     const {
         avatar,
         chevron,
@@ -157,8 +157,8 @@ const InfoListItemRender: React.ForwardRefRenderFunction<unknown, InfoListItemPr
     } = props;
 
     const combine = useCallback(
-        (className: keyof InfoListItemClasses): string => cx(defaultClasses[className]),
-        [defaultClasses]
+        (className: keyof InfoListItemClasses): string => cx(generatedClasses[className]),
+        [generatedClasses]
     );
 
     const getIcon = useCallback((): JSX.Element | undefined => {

--- a/components/src/core/ListItemTag/ListItemTag.tsx
+++ b/components/src/core/ListItemTag/ListItemTag.tsx
@@ -78,13 +78,13 @@ const ListItemTagRender: React.ForwardRefRenderFunction<unknown, ListItemTagProp
     ref: any
 ) => {
     const { classes: userClasses, label, variant, className: userClassName, ...otherTypographyProps } = props;
-    const defaultClasses = useUtilityClasses(props);
+    const generatedClasses = useUtilityClasses(props);
     const { root: rootUserClass, ...otherUserClasses } = userClasses;
     return (
         <Root
             ref={ref}
             variant={variant || 'overline'}
-            className={cx(defaultClasses.root, { [defaultClasses.noVariant]: !variant }, userClassName)}
+            className={cx(generatedClasses.root, { [generatedClasses.noVariant]: !variant }, userClassName)}
             classes={{ root: rootUserClass, ...otherUserClasses }}
             data-testid={'blui-list-item-tag'}
             {...otherTypographyProps}

--- a/components/src/core/ScoreCard/ScoreCard.tsx
+++ b/components/src/core/ScoreCard/ScoreCard.tsx
@@ -279,7 +279,7 @@ const ScoreCardRender: React.ForwardRefRenderFunction<unknown, ScoreCardProps> =
                 </ActionItems>
             ));
         }
-    }, [actionItems, actionLimit, generatedClasses, classes]);
+    }, [actionItems, actionLimit, generatedClasses]);
 
     const getHeroes = useCallback((): JSX.Element | undefined => {
         if (badge) {

--- a/components/src/core/ScoreCard/ScoreCard.tsx
+++ b/components/src/core/ScoreCard/ScoreCard.tsx
@@ -230,7 +230,7 @@ const ScoreCardRender: React.ForwardRefRenderFunction<unknown, ScoreCardProps> =
             );
         }
         return headerInfo;
-    }, [headerInfo, generatedClasses]);
+    }, [headerFontColor, headerInfo, generatedClasses]);
 
     const getHeaderSubtitle = useCallback((): JSX.Element | undefined => {
         if (!headerSubtitle) return;
@@ -247,7 +247,7 @@ const ScoreCardRender: React.ForwardRefRenderFunction<unknown, ScoreCardProps> =
             );
         }
         return headerSubtitle;
-    }, [headerSubtitle, generatedClasses]);
+    }, [headerFontColor, headerSubtitle, generatedClasses]);
 
     const getHeaderText = useCallback(
         (): JSX.Element => (
@@ -264,7 +264,7 @@ const ScoreCardRender: React.ForwardRefRenderFunction<unknown, ScoreCardProps> =
                 {getHeaderInfo()}
             </FlexColumn>
         ),
-        [generatedClasses, headerTitle, getHeaderSubtitle, getHeaderInfo]
+        [generatedClasses, headerFontColor, headerTitle, getHeaderSubtitle, getHeaderInfo]
     );
 
     const getActionItems = useCallback((): JSX.Element[] | undefined => {
@@ -289,7 +289,7 @@ const ScoreCardRender: React.ForwardRefRenderFunction<unknown, ScoreCardProps> =
                 </BadgeWrapper>
             );
         }
-    }, [badge, generatedClasses]);
+    }, [badge, badgeOffset, generatedClasses]);
 
     const getFooter = useCallback((): JSX.Element | undefined => {
         if (actionRow) {

--- a/components/src/core/ScoreCard/ScoreCard.tsx
+++ b/components/src/core/ScoreCard/ScoreCard.tsx
@@ -213,7 +213,7 @@ const ScoreCardRender: React.ForwardRefRenderFunction<unknown, ScoreCardProps> =
                 />
             );
         }
-    }, [headerBackgroundImage, generatedClasses, classes]);
+    }, [headerBackgroundImage, generatedClasses]);
 
     const getHeaderInfo = useCallback((): JSX.Element | undefined => {
         if (!headerInfo) return;

--- a/components/src/core/ScoreCard/ScoreCard.tsx
+++ b/components/src/core/ScoreCard/ScoreCard.tsx
@@ -264,7 +264,7 @@ const ScoreCardRender: React.ForwardRefRenderFunction<unknown, ScoreCardProps> =
                 {getHeaderInfo()}
             </FlexColumn>
         ),
-        [generatedClasses, classes, headerTitle, getHeaderSubtitle, getHeaderInfo]
+        [generatedClasses, headerTitle, getHeaderSubtitle, getHeaderInfo]
     );
 
     const getActionItems = useCallback((): JSX.Element[] | undefined => {

--- a/components/src/core/ScoreCard/ScoreCard.tsx
+++ b/components/src/core/ScoreCard/ScoreCard.tsx
@@ -208,7 +208,7 @@ const ScoreCardRender: React.ForwardRefRenderFunction<unknown, ScoreCardProps> =
         if (headerBackgroundImage) {
             return (
                 <HeaderBackground
-                    className={(generatedClasses.headerBackground)}
+                    className={generatedClasses.headerBackground}
                     headerBackgroundImage={headerBackgroundImage}
                 />
             );
@@ -223,7 +223,7 @@ const ScoreCardRender: React.ForwardRefRenderFunction<unknown, ScoreCardProps> =
                     noWrap
                     variant={'body2'}
                     headerFontColor={headerFontColor}
-                    className={(generatedClasses.headerInfo)}
+                    className={generatedClasses.headerInfo}
                 >
                     {headerInfo}
                 </HeaderInfo>
@@ -240,7 +240,7 @@ const ScoreCardRender: React.ForwardRefRenderFunction<unknown, ScoreCardProps> =
                     headerFontColor={headerFontColor}
                     noWrap
                     variant={'body2'}
-                    className={(generatedClasses.headerSubtitle)}
+                    className={generatedClasses.headerSubtitle}
                 >
                     {headerSubtitle}
                 </HeaderSubtitle>
@@ -256,7 +256,7 @@ const ScoreCardRender: React.ForwardRefRenderFunction<unknown, ScoreCardProps> =
                     headerFontColor={headerFontColor}
                     variant={'h6'}
                     noWrap
-                    className={(generatedClasses.headerTitle)}
+                    className={generatedClasses.headerTitle}
                 >
                     {headerTitle}
                 </HeaderTitle>
@@ -270,11 +270,7 @@ const ScoreCardRender: React.ForwardRefRenderFunction<unknown, ScoreCardProps> =
     const getActionItems = useCallback((): JSX.Element[] | undefined => {
         if (actionItems) {
             return actionItems.slice(0, actionLimit).map((actionItem, index) => (
-                <ActionItems
-                    key={`${index}`}
-                    className={(generatedClasses.actionItems)}
-                    data-testid={'blui-action-item'}
-                >
+                <ActionItems key={`${index}`} className={generatedClasses.actionItems} data-testid={'blui-action-item'}>
                     {actionItem}
                 </ActionItems>
             ));
@@ -285,7 +281,7 @@ const ScoreCardRender: React.ForwardRefRenderFunction<unknown, ScoreCardProps> =
         if (badge) {
             return (
                 <BadgeWrapper
-                    className={(generatedClasses.badgeWrapper)}
+                    className={generatedClasses.badgeWrapper}
                     badgeOffset={badgeOffset}
                     data-testid={'blui-badge-wrapper'}
                 >
@@ -315,18 +311,18 @@ const ScoreCardRender: React.ForwardRefRenderFunction<unknown, ScoreCardProps> =
         >
             <Header
                 data-testid={'blui-score-card-header'}
-                className={(generatedClasses.header)}
+                className={generatedClasses.header}
                 headerColor={headerColor}
                 headerFontColor={headerFontColor}
             >
                 {getBackgroundImage()}
-                <HeaderContent className={(generatedClasses.headerContent)}>
+                <HeaderContent className={generatedClasses.headerContent}>
                     {getHeaderText()}
                     {getActionItems()}
                 </HeaderContent>
             </Header>
-            <Content className={(generatedClasses.content)} data-testid={'blui-body-content'}>
-                <BodyWrapper className={(generatedClasses.bodyWrapper)} data-testid={'blui-body-wrapper'}>
+            <Content className={generatedClasses.content} data-testid={'blui-body-content'}>
+                <BodyWrapper className={generatedClasses.bodyWrapper} data-testid={'blui-body-wrapper'}>
                     {children}
                 </BodyWrapper>
                 {getHeroes()}

--- a/components/src/core/ScoreCard/ScoreCard.tsx
+++ b/components/src/core/ScoreCard/ScoreCard.tsx
@@ -202,18 +202,18 @@ const ScoreCardRender: React.ForwardRefRenderFunction<unknown, ScoreCardProps> =
         ...otherCardProps
     } = props;
 
-    const defaultClasses = useUtilityClasses(props);
+    const generatedClasses = useUtilityClasses(props);
 
     const getBackgroundImage = useCallback((): JSX.Element | undefined => {
         if (headerBackgroundImage) {
             return (
                 <HeaderBackground
-                    className={cx(defaultClasses.headerBackground)}
+                    className={(generatedClasses.headerBackground)}
                     headerBackgroundImage={headerBackgroundImage}
                 />
             );
         }
-    }, [headerBackgroundImage, defaultClasses, classes]);
+    }, [headerBackgroundImage, generatedClasses, classes]);
 
     const getHeaderInfo = useCallback((): JSX.Element | undefined => {
         if (!headerInfo) return;
@@ -223,14 +223,14 @@ const ScoreCardRender: React.ForwardRefRenderFunction<unknown, ScoreCardProps> =
                     noWrap
                     variant={'body2'}
                     headerFontColor={headerFontColor}
-                    className={cx(defaultClasses.headerInfo)}
+                    className={(generatedClasses.headerInfo)}
                 >
                     {headerInfo}
                 </HeaderInfo>
             );
         }
         return headerInfo;
-    }, [headerInfo, defaultClasses, classes]);
+    }, [headerInfo, generatedClasses, classes]);
 
     const getHeaderSubtitle = useCallback((): JSX.Element | undefined => {
         if (!headerSubtitle) return;
@@ -240,14 +240,14 @@ const ScoreCardRender: React.ForwardRefRenderFunction<unknown, ScoreCardProps> =
                     headerFontColor={headerFontColor}
                     noWrap
                     variant={'body2'}
-                    className={cx(defaultClasses.headerSubtitle)}
+                    className={(generatedClasses.headerSubtitle)}
                 >
                     {headerSubtitle}
                 </HeaderSubtitle>
             );
         }
         return headerSubtitle;
-    }, [headerSubtitle, defaultClasses, classes]);
+    }, [headerSubtitle, generatedClasses, classes]);
 
     const getHeaderText = useCallback(
         (): JSX.Element => (
@@ -256,7 +256,7 @@ const ScoreCardRender: React.ForwardRefRenderFunction<unknown, ScoreCardProps> =
                     headerFontColor={headerFontColor}
                     variant={'h6'}
                     noWrap
-                    className={cx(defaultClasses.headerTitle)}
+                    className={(generatedClasses.headerTitle)}
                 >
                     {headerTitle}
                 </HeaderTitle>
@@ -264,7 +264,7 @@ const ScoreCardRender: React.ForwardRefRenderFunction<unknown, ScoreCardProps> =
                 {getHeaderInfo()}
             </FlexColumn>
         ),
-        [defaultClasses, classes, headerTitle, getHeaderSubtitle, getHeaderInfo]
+        [generatedClasses, classes, headerTitle, getHeaderSubtitle, getHeaderInfo]
     );
 
     const getActionItems = useCallback((): JSX.Element[] | undefined => {
@@ -272,20 +272,20 @@ const ScoreCardRender: React.ForwardRefRenderFunction<unknown, ScoreCardProps> =
             return actionItems.slice(0, actionLimit).map((actionItem, index) => (
                 <ActionItems
                     key={`${index}`}
-                    className={cx(defaultClasses.actionItems)}
+                    className={(generatedClasses.actionItems)}
                     data-testid={'blui-action-item'}
                 >
                     {actionItem}
                 </ActionItems>
             ));
         }
-    }, [actionItems, actionLimit, defaultClasses, classes]);
+    }, [actionItems, actionLimit, generatedClasses, classes]);
 
     const getHeroes = useCallback((): JSX.Element | undefined => {
         if (badge) {
             return (
                 <BadgeWrapper
-                    className={cx(defaultClasses.badgeWrapper)}
+                    className={(generatedClasses.badgeWrapper)}
                     badgeOffset={badgeOffset}
                     data-testid={'blui-badge-wrapper'}
                 >
@@ -293,7 +293,7 @@ const ScoreCardRender: React.ForwardRefRenderFunction<unknown, ScoreCardProps> =
                 </BadgeWrapper>
             );
         }
-    }, [badge, defaultClasses, classes]);
+    }, [badge, generatedClasses, classes]);
 
     const getFooter = useCallback((): JSX.Element | undefined => {
         if (actionRow) {
@@ -309,24 +309,24 @@ const ScoreCardRender: React.ForwardRefRenderFunction<unknown, ScoreCardProps> =
     return (
         <Root
             ref={ref}
-            className={cx(defaultClasses.root, userClassName)}
+            className={cx(generatedClasses.root, userClassName)}
             data-testid={'blui-score-card-root'}
             {...otherCardProps}
         >
             <Header
                 data-testid={'blui-score-card-header'}
-                className={cx(defaultClasses.header)}
+                className={(generatedClasses.header)}
                 headerColor={headerColor}
                 headerFontColor={headerFontColor}
             >
                 {getBackgroundImage()}
-                <HeaderContent className={cx(defaultClasses.headerContent)}>
+                <HeaderContent className={(generatedClasses.headerContent)}>
                     {getHeaderText()}
                     {getActionItems()}
                 </HeaderContent>
             </Header>
-            <Content className={cx(defaultClasses.content)} data-testid={'blui-body-content'}>
-                <BodyWrapper className={cx(defaultClasses.bodyWrapper)} data-testid={'blui-body-wrapper'}>
+            <Content className={(generatedClasses.content)} data-testid={'blui-body-content'}>
+                <BodyWrapper className={(generatedClasses.bodyWrapper)} data-testid={'blui-body-wrapper'}>
                     {children}
                 </BodyWrapper>
                 {getHeroes()}

--- a/components/src/core/ScoreCard/ScoreCard.tsx
+++ b/components/src/core/ScoreCard/ScoreCard.tsx
@@ -230,7 +230,7 @@ const ScoreCardRender: React.ForwardRefRenderFunction<unknown, ScoreCardProps> =
             );
         }
         return headerInfo;
-    }, [headerInfo, generatedClasses, classes]);
+    }, [headerInfo, generatedClasses]);
 
     const getHeaderSubtitle = useCallback((): JSX.Element | undefined => {
         if (!headerSubtitle) return;

--- a/components/src/core/ScoreCard/ScoreCard.tsx
+++ b/components/src/core/ScoreCard/ScoreCard.tsx
@@ -293,7 +293,7 @@ const ScoreCardRender: React.ForwardRefRenderFunction<unknown, ScoreCardProps> =
                 </BadgeWrapper>
             );
         }
-    }, [badge, generatedClasses, classes]);
+    }, [badge, generatedClasses]);
 
     const getFooter = useCallback((): JSX.Element | undefined => {
         if (actionRow) {

--- a/components/src/core/ScoreCard/ScoreCard.tsx
+++ b/components/src/core/ScoreCard/ScoreCard.tsx
@@ -208,7 +208,7 @@ const ScoreCardRender: React.ForwardRefRenderFunction<unknown, ScoreCardProps> =
         if (headerBackgroundImage) {
             return (
                 <HeaderBackground
-                    className={cx(defaultClasses.headerBackground, classes.headerBackground)}
+                    className={cx(defaultClasses.headerBackground)}
                     headerBackgroundImage={headerBackgroundImage}
                 />
             );
@@ -223,7 +223,7 @@ const ScoreCardRender: React.ForwardRefRenderFunction<unknown, ScoreCardProps> =
                     noWrap
                     variant={'body2'}
                     headerFontColor={headerFontColor}
-                    className={cx(defaultClasses.headerInfo, classes.headerInfo)}
+                    className={cx(defaultClasses.headerInfo)}
                 >
                     {headerInfo}
                 </HeaderInfo>
@@ -240,7 +240,7 @@ const ScoreCardRender: React.ForwardRefRenderFunction<unknown, ScoreCardProps> =
                     headerFontColor={headerFontColor}
                     noWrap
                     variant={'body2'}
-                    className={cx(defaultClasses.headerSubtitle, classes.headerSubtitle)}
+                    className={cx(defaultClasses.headerSubtitle)}
                 >
                     {headerSubtitle}
                 </HeaderSubtitle>
@@ -256,7 +256,7 @@ const ScoreCardRender: React.ForwardRefRenderFunction<unknown, ScoreCardProps> =
                     headerFontColor={headerFontColor}
                     variant={'h6'}
                     noWrap
-                    className={cx(defaultClasses.headerTitle, classes.headerTitle)}
+                    className={cx(defaultClasses.headerTitle)}
                 >
                     {headerTitle}
                 </HeaderTitle>
@@ -272,7 +272,7 @@ const ScoreCardRender: React.ForwardRefRenderFunction<unknown, ScoreCardProps> =
             return actionItems.slice(0, actionLimit).map((actionItem, index) => (
                 <ActionItems
                     key={`${index}`}
-                    className={cx(defaultClasses.actionItems, classes.actionItems)}
+                    className={cx(defaultClasses.actionItems)}
                     data-testid={'blui-action-item'}
                 >
                     {actionItem}
@@ -285,7 +285,7 @@ const ScoreCardRender: React.ForwardRefRenderFunction<unknown, ScoreCardProps> =
         if (badge) {
             return (
                 <BadgeWrapper
-                    className={cx(defaultClasses.badgeWrapper, classes.badgeWrapper)}
+                    className={cx(defaultClasses.badgeWrapper)}
                     badgeOffset={badgeOffset}
                     data-testid={'blui-badge-wrapper'}
                 >
@@ -309,27 +309,24 @@ const ScoreCardRender: React.ForwardRefRenderFunction<unknown, ScoreCardProps> =
     return (
         <Root
             ref={ref}
-            className={cx(defaultClasses.root, classes.root, userClassName)}
+            className={cx(defaultClasses.root, userClassName)}
             data-testid={'blui-score-card-root'}
             {...otherCardProps}
         >
             <Header
                 data-testid={'blui-score-card-header'}
-                className={cx(defaultClasses.header, classes.header)}
+                className={cx(defaultClasses.header)}
                 headerColor={headerColor}
                 headerFontColor={headerFontColor}
             >
                 {getBackgroundImage()}
-                <HeaderContent className={cx(defaultClasses.headerContent, classes.headerContent)}>
+                <HeaderContent className={cx(defaultClasses.headerContent)}>
                     {getHeaderText()}
                     {getActionItems()}
                 </HeaderContent>
             </Header>
-            <Content className={cx(defaultClasses.content, classes.content)} data-testid={'blui-body-content'}>
-                <BodyWrapper
-                    className={cx(defaultClasses.bodyWrapper, classes.bodyWrapper)}
-                    data-testid={'blui-body-wrapper'}
-                >
+            <Content className={cx(defaultClasses.content)} data-testid={'blui-body-content'}>
+                <BodyWrapper className={cx(defaultClasses.bodyWrapper)} data-testid={'blui-body-wrapper'}>
                     {children}
                 </BodyWrapper>
                 {getHeroes()}

--- a/components/src/core/ScoreCard/ScoreCard.tsx
+++ b/components/src/core/ScoreCard/ScoreCard.tsx
@@ -247,7 +247,7 @@ const ScoreCardRender: React.ForwardRefRenderFunction<unknown, ScoreCardProps> =
             );
         }
         return headerSubtitle;
-    }, [headerSubtitle, generatedClasses, classes]);
+    }, [headerSubtitle, generatedClasses]);
 
     const getHeaderText = useCallback(
         (): JSX.Element => (

--- a/components/src/core/ThreeLiner/ThreeLiner.tsx
+++ b/components/src/core/ThreeLiner/ThreeLiner.tsx
@@ -90,6 +90,7 @@ const ThreeLinerRenderer: React.ForwardRefRenderFunction<unknown, ThreeLinerProp
         title,
         subtitle,
         info,
+        classes = {},
         className: userClassName,
         // ignore unused vars so that we can do prop transferring to the root element
         /* eslint-disable @typescript-eslint/no-unused-vars */
@@ -105,9 +106,9 @@ const ThreeLinerRenderer: React.ForwardRefRenderFunction<unknown, ThreeLinerProp
             animationDuration={animationDuration}
             className={cx(generatedClasses.root, userClassName)}
         >
-            <Title className={(generatedClasses.title)}>{title}</Title>
-            <Subtitle className={(generatedClasses.subtitle)}>{subtitle}</Subtitle>
-            <Info className={(generatedClasses.info)}>{info}</Info>
+            <Title className={generatedClasses.title}>{title}</Title>
+            <Subtitle className={generatedClasses.subtitle}>{subtitle}</Subtitle>
+            <Info className={generatedClasses.info}>{info}</Info>
         </Root>
     );
 };

--- a/components/src/core/ThreeLiner/ThreeLiner.tsx
+++ b/components/src/core/ThreeLiner/ThreeLiner.tsx
@@ -96,18 +96,18 @@ const ThreeLinerRenderer: React.ForwardRefRenderFunction<unknown, ThreeLinerProp
         animationDuration,
         ...otherProps
     } = props;
-    const defaultClasses = useUtilityClasses(props);
+    const generatedClasses = useUtilityClasses(props);
     //const animationDuration = durationProp || theme.transitions.duration.standard;
     return (
         <Root
             ref={ref}
             {...otherProps}
             animationDuration={animationDuration}
-            className={cx(defaultClasses.root, userClassName)}
+            className={cx(generatedClasses.root, userClassName)}
         >
-            <Title className={cx(defaultClasses.title)}>{title}</Title>
-            <Subtitle className={cx(defaultClasses.subtitle)}>{subtitle}</Subtitle>
-            <Info className={cx(defaultClasses.info)}>{info}</Info>
+            <Title className={(generatedClasses.title)}>{title}</Title>
+            <Subtitle className={(generatedClasses.subtitle)}>{subtitle}</Subtitle>
+            <Info className={(generatedClasses.info)}>{info}</Info>
         </Root>
     );
 };

--- a/components/src/core/ThreeLiner/ThreeLiner.tsx
+++ b/components/src/core/ThreeLiner/ThreeLiner.tsx
@@ -90,7 +90,6 @@ const ThreeLinerRenderer: React.ForwardRefRenderFunction<unknown, ThreeLinerProp
         title,
         subtitle,
         info,
-        classes = {},
         className: userClassName,
         // ignore unused vars so that we can do prop transferring to the root element
         /* eslint-disable @typescript-eslint/no-unused-vars */

--- a/components/src/core/ThreeLiner/ThreeLiner.tsx
+++ b/components/src/core/ThreeLiner/ThreeLiner.tsx
@@ -90,7 +90,6 @@ const ThreeLinerRenderer: React.ForwardRefRenderFunction<unknown, ThreeLinerProp
         title,
         subtitle,
         info,
-        classes = {},
         className: userClassName,
         // ignore unused vars so that we can do prop transferring to the root element
         /* eslint-disable @typescript-eslint/no-unused-vars */
@@ -104,11 +103,11 @@ const ThreeLinerRenderer: React.ForwardRefRenderFunction<unknown, ThreeLinerProp
             ref={ref}
             {...otherProps}
             animationDuration={animationDuration}
-            className={cx(defaultClasses.root, classes.root, userClassName)}
+            className={cx(defaultClasses.root, userClassName)}
         >
-            <Title className={cx(defaultClasses.title, classes.title)}>{title}</Title>
-            <Subtitle className={cx(defaultClasses.subtitle, classes.subtitle)}>{subtitle}</Subtitle>
-            <Info className={cx(defaultClasses.info, classes.info)}>{info}</Info>
+            <Title className={cx(defaultClasses.title)}>{title}</Title>
+            <Subtitle className={cx(defaultClasses.subtitle)}>{subtitle}</Subtitle>
+            <Info className={cx(defaultClasses.info)}>{info}</Info>
         </Root>
     );
 };

--- a/components/src/core/ToolbarMenu/ToolbarMenu.tsx
+++ b/components/src/core/ToolbarMenu/ToolbarMenu.tsx
@@ -120,6 +120,7 @@ const ToolbarMenuRenderer: React.ForwardRefRenderFunction<unknown, ToolbarMenuPr
         onClose,
         onOpen,
         className: userClassName,
+        classes = {},
         ...otherTypographyProps
     } = props;
     const theme = useTheme();
@@ -221,7 +222,7 @@ const ToolbarMenuRenderer: React.ForwardRefRenderFunction<unknown, ToolbarMenuPr
                 {icon && (
                     <ToolbarMenuIcon
                         component={'span'}
-                        className={(generatedClasses.icon)}
+                        className={generatedClasses.icon}
                         data-testid={'blui-toolbar-menu-icon'}
                     >
                         {icon}
@@ -229,7 +230,7 @@ const ToolbarMenuRenderer: React.ForwardRefRenderFunction<unknown, ToolbarMenuPr
                 )}
                 <ToolbarMenuLabel
                     component={'span'}
-                    className={(generatedClasses.label)}
+                    className={generatedClasses.label}
                     data-testid={'blui-toolbar-menu-label'}
                 >
                     {label || ''}

--- a/components/src/core/ToolbarMenu/ToolbarMenu.tsx
+++ b/components/src/core/ToolbarMenu/ToolbarMenu.tsx
@@ -120,7 +120,6 @@ const ToolbarMenuRenderer: React.ForwardRefRenderFunction<unknown, ToolbarMenuPr
         onClose,
         onOpen,
         className: userClassName,
-        classes = {},
         ...otherTypographyProps
     } = props;
     const theme = useTheme();

--- a/components/src/core/ToolbarMenu/ToolbarMenu.tsx
+++ b/components/src/core/ToolbarMenu/ToolbarMenu.tsx
@@ -159,7 +159,7 @@ const ToolbarMenuRenderer: React.ForwardRefRenderFunction<unknown, ToolbarMenuPr
                 }
             }
         }
-    }, [menuGroups]);
+    }, [closeMenu, menuGroups]);
 
     const getMenu = useCallback(() => {
         if (menu && Boolean(anchorEl)) {
@@ -200,7 +200,7 @@ const ToolbarMenuRenderer: React.ForwardRefRenderFunction<unknown, ToolbarMenuPr
                 </Menu>
             );
         }
-    }, [menuGroups, menu, anchorEl, MenuProps, generatedClasses]);
+    }, [closeMenu, menuGroups, menu, anchorEl, MenuProps, generatedClasses, rtl]);
 
     return (
         <>

--- a/components/src/core/ToolbarMenu/ToolbarMenu.tsx
+++ b/components/src/core/ToolbarMenu/ToolbarMenu.tsx
@@ -120,7 +120,6 @@ const ToolbarMenuRenderer: React.ForwardRefRenderFunction<unknown, ToolbarMenuPr
         onClose,
         onOpen,
         className: userClassName,
-        classes = {},
         ...otherTypographyProps
     } = props;
     const theme = useTheme();
@@ -211,7 +210,6 @@ const ToolbarMenuRenderer: React.ForwardRefRenderFunction<unknown, ToolbarMenuPr
                 {...otherTypographyProps}
                 className={cx(
                     defaultClasses.root,
-                    classes.root,
                     userClassName,
                     menuGroups || menu ? defaultClasses.cursorPointer : ''
                 )}
@@ -223,7 +221,7 @@ const ToolbarMenuRenderer: React.ForwardRefRenderFunction<unknown, ToolbarMenuPr
                 {icon && (
                     <ToolbarMenuIcon
                         component={'span'}
-                        className={cx(defaultClasses.icon, classes.icon)}
+                        className={cx(defaultClasses.icon)}
                         data-testid={'blui-toolbar-menu-icon'}
                     >
                         {icon}
@@ -231,7 +229,7 @@ const ToolbarMenuRenderer: React.ForwardRefRenderFunction<unknown, ToolbarMenuPr
                 )}
                 <ToolbarMenuLabel
                     component={'span'}
-                    className={cx(defaultClasses.label, classes.label)}
+                    className={cx(defaultClasses.label)}
                     data-testid={'blui-toolbar-menu-label'}
                 >
                     {label || ''}
@@ -241,7 +239,6 @@ const ToolbarMenuRenderer: React.ForwardRefRenderFunction<unknown, ToolbarMenuPr
                         data-testid={'blui-arrow-dropdown'}
                         className={cx(
                             defaultClasses.dropdownArrow,
-                            classes.dropdownArrow,
                             anchorEl ? defaultClasses.rotatedDropdownArrow : ''
                         )}
                     />

--- a/components/src/core/ToolbarMenu/ToolbarMenu.tsx
+++ b/components/src/core/ToolbarMenu/ToolbarMenu.tsx
@@ -124,7 +124,7 @@ const ToolbarMenuRenderer: React.ForwardRefRenderFunction<unknown, ToolbarMenuPr
     } = props;
     const theme = useTheme();
     const rtl = theme.direction === 'rtl';
-    const defaultClasses = useUtilityClasses(props);
+    const generatedClasses = useUtilityClasses(props);
     const [anchorEl, setAnchorEl] = useState(null);
     const anchor = useRef(null);
 
@@ -183,7 +183,7 @@ const ToolbarMenuRenderer: React.ForwardRefRenderFunction<unknown, ToolbarMenuPr
                 >
                     {!menu &&
                         menuGroups.map((group: ToolbarMenuCompGroup, index: number) => (
-                            <ToolbarMenuNavGroups className={defaultClasses.navGroups} key={index}>
+                            <ToolbarMenuNavGroups className={generatedClasses.navGroups} key={index}>
                                 <DrawerNavGroup
                                     divider={false}
                                     hidePadding={true}
@@ -200,7 +200,7 @@ const ToolbarMenuRenderer: React.ForwardRefRenderFunction<unknown, ToolbarMenuPr
                 </Menu>
             );
         }
-    }, [menuGroups, menu, anchorEl, MenuProps, defaultClasses]);
+    }, [menuGroups, menu, anchorEl, MenuProps, generatedClasses]);
 
     return (
         <>
@@ -209,9 +209,9 @@ const ToolbarMenuRenderer: React.ForwardRefRenderFunction<unknown, ToolbarMenuPr
                 aria-haspopup="true"
                 {...otherTypographyProps}
                 className={cx(
-                    defaultClasses.root,
+                    generatedClasses.root,
                     userClassName,
-                    menuGroups || menu ? defaultClasses.cursorPointer : ''
+                    menuGroups || menu ? generatedClasses.cursorPointer : ''
                 )}
                 data-testid={'blui-menu-root'}
                 onClick={(): void => {
@@ -221,7 +221,7 @@ const ToolbarMenuRenderer: React.ForwardRefRenderFunction<unknown, ToolbarMenuPr
                 {icon && (
                     <ToolbarMenuIcon
                         component={'span'}
-                        className={cx(defaultClasses.icon)}
+                        className={(generatedClasses.icon)}
                         data-testid={'blui-toolbar-menu-icon'}
                     >
                         {icon}
@@ -229,7 +229,7 @@ const ToolbarMenuRenderer: React.ForwardRefRenderFunction<unknown, ToolbarMenuPr
                 )}
                 <ToolbarMenuLabel
                     component={'span'}
-                    className={cx(defaultClasses.label)}
+                    className={(generatedClasses.label)}
                     data-testid={'blui-toolbar-menu-label'}
                 >
                     {label || ''}
@@ -238,8 +238,8 @@ const ToolbarMenuRenderer: React.ForwardRefRenderFunction<unknown, ToolbarMenuPr
                     <DropDownArrow
                         data-testid={'blui-arrow-dropdown'}
                         className={cx(
-                            defaultClasses.dropdownArrow,
-                            anchorEl ? defaultClasses.rotatedDropdownArrow : ''
+                            generatedClasses.dropdownArrow,
+                            anchorEl ? generatedClasses.rotatedDropdownArrow : ''
                         )}
                     />
                 )}

--- a/components/src/core/UserMenu/UserMenu.tsx
+++ b/components/src/core/UserMenu/UserMenu.tsx
@@ -155,7 +155,7 @@ const UserMenuRender: React.ForwardRefRenderFunction<unknown, UserMenuProps> = (
                 }
             }
         }
-    }, [menuGroups]);
+    }, [closeMenu, menuGroups]);
 
     const canDisplayMenu = useCallback(() => Boolean(menu || menuGroups.length > 0), [menu, menuGroups]);
 
@@ -193,7 +193,7 @@ const UserMenuRender: React.ForwardRefRenderFunction<unknown, UserMenuProps> = (
                 },
             });
         },
-        [avatar, onOpen, generatedClasses]
+        [avatar, openMenu, generatedClasses]
     );
 
     /* DrawerHeader needs wrapped with key div to avoid ref warning on FC. */
@@ -218,7 +218,15 @@ const UserMenuRender: React.ForwardRefRenderFunction<unknown, UserMenuProps> = (
                 </Header>
             );
         }
-    }, [menuTitle, menuSubtitle, avatar]);
+    }, [
+        formatAvatar,
+        menuTitle,
+        menuSubtitle,
+        generatedClasses.header,
+        generatedClasses.headerRoot,
+        generatedClasses.menuTitle,
+        generatedClasses.navigation,
+    ]);
 
     /* DrawerNavGroup needs wrapped with key div to avoid ref warning on FC. */
     const printMenuItems = useCallback(
@@ -245,7 +253,7 @@ const UserMenuRender: React.ForwardRefRenderFunction<unknown, UserMenuProps> = (
                     />
                 </UserMenuNavGroups>
             )),
-        [menuGroups, generatedClasses]
+        [menuGroups, generatedClasses, theme.palette.text.secondary]
     );
 
     const printMenu = useCallback(
@@ -290,7 +298,17 @@ const UserMenuRender: React.ForwardRefRenderFunction<unknown, UserMenuProps> = (
                 {printMenu()}
             </Menu>
         );
-    }, [menu, anchorEl, closeMenu, MenuProps, printMenu, useBottomSheetAt, BottomSheetProps]);
+    }, [
+        menu,
+        anchorEl,
+        closeMenu,
+        MenuProps,
+        printMenu,
+        useBottomSheetAt,
+        BottomSheetProps,
+        generatedClasses.bottomSheet,
+        theme.transitions.duration.short,
+    ]);
 
     return (
         <Root ref={ref} className={generatedClasses.root} {...otherProps}>

--- a/components/src/core/UserMenu/UserMenu.tsx
+++ b/components/src/core/UserMenu/UserMenu.tsx
@@ -134,7 +134,7 @@ const UserMenuRender: React.ForwardRefRenderFunction<unknown, UserMenuProps> = (
         onOpen,
         ...otherProps
     } = props;
-    const defaultClasses = useUtilityClasses(props);
+    const generatedClasses = useUtilityClasses(props);
     const [anchorEl, setAnchorEl] = useState(null);
 
     const closeMenu = useCallback(() => {
@@ -186,14 +186,14 @@ const UserMenuRender: React.ForwardRefRenderFunction<unknown, UserMenuProps> = (
                 classes: {
                     ...aProps.classes,
                     root: cx(
-                        defaultClasses.avatarRoot,
-                        preserveOnClick ? '' : defaultClasses.noCursor,
+                        generatedClasses.avatarRoot,
+                        preserveOnClick ? '' : generatedClasses.noCursor,
                         aProps?.classes?.root
                     ),
                 },
             });
         },
-        [avatar, onOpen, defaultClasses, classes]
+        [avatar, onOpen, generatedClasses, classes]
     );
 
     /* DrawerHeader needs wrapped with key div to avoid ref warning on FC. */
@@ -201,7 +201,7 @@ const UserMenuRender: React.ForwardRefRenderFunction<unknown, UserMenuProps> = (
         if (menuTitle) {
             const nonClickableAvatar = formatAvatar(false);
             return (
-                <Header className={defaultClasses.header} key={'header'}>
+                <Header className={generatedClasses.header} key={'header'}>
                     <DrawerHeader
                         icon={nonClickableAvatar}
                         title={menuTitle}
@@ -210,9 +210,9 @@ const UserMenuRender: React.ForwardRefRenderFunction<unknown, UserMenuProps> = (
                         backgroundColor={'inherit'}
                         divider
                         classes={{
-                            root: defaultClasses.headerRoot,
-                            title: defaultClasses.menuTitle,
-                            navigation: defaultClasses.navigation,
+                            root: generatedClasses.headerRoot,
+                            title: generatedClasses.menuTitle,
+                            navigation: generatedClasses.navigation,
                         }}
                     />
                 </Header>
@@ -224,7 +224,7 @@ const UserMenuRender: React.ForwardRefRenderFunction<unknown, UserMenuProps> = (
     const printMenuItems = useCallback(
         (): JSX.Element[] =>
             menuGroups.map((group: UserMenuGroup, index: number) => (
-                <UserMenuNavGroups className={defaultClasses.navGroups} key={index}>
+                <UserMenuNavGroups className={generatedClasses.navGroups} key={index}>
                     <DrawerNavGroup
                         divider={false}
                         itemIconColor={group.iconColor}
@@ -245,7 +245,7 @@ const UserMenuRender: React.ForwardRefRenderFunction<unknown, UserMenuProps> = (
                     />
                 </UserMenuNavGroups>
             )),
-        [menuGroups, defaultClasses]
+        [menuGroups, generatedClasses]
     );
 
     const printMenu = useCallback(
@@ -273,7 +273,7 @@ const UserMenuRender: React.ForwardRefRenderFunction<unknown, UserMenuProps> = (
                 open={Boolean(anchorEl)}
                 onClose={closeMenu}
                 disablePortal
-                classes={{ paper: cx(defaultClasses.bottomSheet, classes.bottomSheet) }}
+                classes={{ paper: cx(generatedClasses.bottomSheet, classes.bottomSheet) }}
                 {...BottomSheetProps}
             >
                 {printMenu()}
@@ -293,7 +293,7 @@ const UserMenuRender: React.ForwardRefRenderFunction<unknown, UserMenuProps> = (
     }, [menu, anchorEl, closeMenu, MenuProps, printMenu, useBottomSheetAt, BottomSheetProps]);
 
     return (
-        <Root ref={ref} className={cx(defaultClasses.root)} {...otherProps}>
+        <Root ref={ref} className={(generatedClasses.root)} {...otherProps}>
             {formatAvatar(true)}
             {canDisplayMenu() && formatMenu()}
         </Root>

--- a/components/src/core/UserMenu/UserMenu.tsx
+++ b/components/src/core/UserMenu/UserMenu.tsx
@@ -263,8 +263,6 @@ const UserMenuRender: React.ForwardRefRenderFunction<unknown, UserMenuProps> = (
     );
 
     const formatMenu = useCallback((): JSX.Element => {
-        // const showBottomSheet = useMediaQuery(`(max-width:${useBottomSheetAt}px)`);
-
         /* If the user provides a menu, provide default props. */
         if (menu) {
             return React.cloneElement(menu, {

--- a/components/src/core/UserMenu/UserMenu.tsx
+++ b/components/src/core/UserMenu/UserMenu.tsx
@@ -193,7 +193,7 @@ const UserMenuRender: React.ForwardRefRenderFunction<unknown, UserMenuProps> = (
                 },
             });
         },
-        [avatar, onOpen, generatedClasses, classes]
+        [avatar, onOpen, generatedClasses]
     );
 
     /* DrawerHeader needs wrapped with key div to avoid ref warning on FC. */

--- a/components/src/core/UserMenu/UserMenu.tsx
+++ b/components/src/core/UserMenu/UserMenu.tsx
@@ -273,7 +273,7 @@ const UserMenuRender: React.ForwardRefRenderFunction<unknown, UserMenuProps> = (
                 open={Boolean(anchorEl)}
                 onClose={closeMenu}
                 disablePortal
-                classes={{ paper: cx(generatedClasses.bottomSheet, classes.bottomSheet) }}
+                classes={{ paper: cx(generatedClasses.bottomSheet) }}
                 {...BottomSheetProps}
             >
                 {printMenu()}

--- a/components/src/core/UserMenu/UserMenu.tsx
+++ b/components/src/core/UserMenu/UserMenu.tsx
@@ -293,7 +293,7 @@ const UserMenuRender: React.ForwardRefRenderFunction<unknown, UserMenuProps> = (
     }, [menu, anchorEl, closeMenu, MenuProps, printMenu, useBottomSheetAt, BottomSheetProps]);
 
     return (
-        <Root ref={ref} className={cx(defaultClasses.root, classes.root)} {...otherProps}>
+        <Root ref={ref} className={cx(defaultClasses.root)} {...otherProps}>
             {formatAvatar(true)}
             {canDisplayMenu() && formatMenu()}
         </Root>

--- a/components/src/core/UserMenu/UserMenu.tsx
+++ b/components/src/core/UserMenu/UserMenu.tsx
@@ -293,7 +293,7 @@ const UserMenuRender: React.ForwardRefRenderFunction<unknown, UserMenuProps> = (
     }, [menu, anchorEl, closeMenu, MenuProps, printMenu, useBottomSheetAt, BottomSheetProps]);
 
     return (
-        <Root ref={ref} className={(generatedClasses.root)} {...otherProps}>
+        <Root ref={ref} className={generatedClasses.root} {...otherProps}>
             {formatAvatar(true)}
             {canDisplayMenu() && formatMenu()}
         </Root>

--- a/components/src/core/UserMenu/UserMenu.tsx
+++ b/components/src/core/UserMenu/UserMenu.tsx
@@ -136,6 +136,7 @@ const UserMenuRender: React.ForwardRefRenderFunction<unknown, UserMenuProps> = (
     } = props;
     const generatedClasses = useUtilityClasses(props);
     const [anchorEl, setAnchorEl] = useState(null);
+    const showBottomSheet = useMediaQuery(`(max-width:${useBottomSheetAt}px)`);
 
     const closeMenu = useCallback(() => {
         onClose();
@@ -262,7 +263,7 @@ const UserMenuRender: React.ForwardRefRenderFunction<unknown, UserMenuProps> = (
     );
 
     const formatMenu = useCallback((): JSX.Element => {
-        const showBottomSheet = useMediaQuery(`(max-width:${useBottomSheetAt}px)`);
+        // const showBottomSheet = useMediaQuery(`(max-width:${useBottomSheetAt}px)`);
 
         /* If the user provides a menu, provide default props. */
         if (menu) {
@@ -304,7 +305,7 @@ const UserMenuRender: React.ForwardRefRenderFunction<unknown, UserMenuProps> = (
         closeMenu,
         MenuProps,
         printMenu,
-        useBottomSheetAt,
+        showBottomSheet,
         BottomSheetProps,
         generatedClasses.bottomSheet,
         theme.transitions.duration.short,

--- a/components/src/core/Utility/Spacer.tsx
+++ b/components/src/core/Utility/Spacer.tsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import Box, { BoxProps } from '@mui/material/Box';
 import { unstable_composeClasses as composeClasses } from '@mui/base';
 import { SpacerClasses, getSpacerUtilityClass, SpacerClassKey } from './SpacerClasses';
-import { cx } from '@emotion/css';
 import { styled } from '@mui/material/styles';
 
 const useUtilityClasses = (ownerState: SpacerProps): Record<SpacerClassKey, string> => {
@@ -43,7 +42,7 @@ const SpacerRender: React.ForwardRefRenderFunction<unknown, SpacerProps> = (prop
     const ownerState = {
         ...props,
     };
-    const defaultClasses = useUtilityClasses(ownerState);
+    const generatedClasses = useUtilityClasses(ownerState);
 
     return (
         <Root
@@ -52,7 +51,7 @@ const SpacerRender: React.ForwardRefRenderFunction<unknown, SpacerProps> = (prop
             flex={flex}
             height={height}
             width={width}
-            className={cx(defaultClasses.root)}
+            className={(generatedClasses.root)}
             {...otherProps}
         >
             {children}

--- a/components/src/core/Utility/Spacer.tsx
+++ b/components/src/core/Utility/Spacer.tsx
@@ -39,7 +39,7 @@ const Root = styled(
 }));
 
 const SpacerRender: React.ForwardRefRenderFunction<unknown, SpacerProps> = (props: SpacerProps, ref: any) => {
-    const { children, classes, flex, height, width, ...otherProps } = props;
+    const { children, flex, height, width, ...otherProps } = props;
     const ownerState = {
         ...props,
     };
@@ -52,7 +52,7 @@ const SpacerRender: React.ForwardRefRenderFunction<unknown, SpacerProps> = (prop
             flex={flex}
             height={height}
             width={width}
-            className={cx(defaultClasses.root, classes.root)}
+            className={cx(defaultClasses.root)}
             {...otherProps}
         >
             {children}

--- a/components/src/core/Utility/Spacer.tsx
+++ b/components/src/core/Utility/Spacer.tsx
@@ -51,7 +51,7 @@ const SpacerRender: React.ForwardRefRenderFunction<unknown, SpacerProps> = (prop
             flex={flex}
             height={height}
             width={width}
-            className={(generatedClasses.root)}
+            className={generatedClasses.root}
             {...otherProps}
         >
             {children}

--- a/components/yarn.lock
+++ b/components/yarn.lock
@@ -317,12 +317,19 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.19.0"
 
-"@babel/runtime@^7.12.5", "@babel/runtime@^7.16.3", "@babel/runtime@^7.18.3", "@babel/runtime@^7.20.1", "@babel/runtime@^7.20.6", "@babel/runtime@^7.20.7", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.12.5", "@babel/runtime@^7.16.3", "@babel/runtime@^7.18.3", "@babel/runtime@^7.20.1", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
   version "7.20.7"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.20.7.tgz#fcb41a5a70550e04a7b708037c7c32f7f356d8fd"
   integrity sha512-UF0tvkUtxwAgZ5W/KrkHf0Rn0fdnLDU9ScxBrEVNUprE/MzirjK4MJUX1/BVDv00Sv8cljtukVK1aky++X1SjQ==
   dependencies:
     regenerator-runtime "^0.13.11"
+
+"@babel/runtime@^7.23.9":
+  version "7.23.9"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.23.9.tgz#47791a15e4603bb5f905bc0753801cf21d6345f7"
+  integrity sha512-0CX6F+BI2s9dkUqr08KFrAIZgNFj75rdBU/DjCyYLIaV/quFjkk6T+EJ2LkZHyZTbEV4L5p97mNkUsHl2wLFAw==
+  dependencies:
+    regenerator-runtime "^0.14.0"
 
 "@babel/template@^7.18.10", "@babel/template@^7.3.3":
   version "7.18.10"
@@ -439,7 +446,7 @@
     source-map "^0.5.7"
     stylis "4.2.0"
 
-"@emotion/cache@^11.10.5", "@emotion/cache@^11.11.0":
+"@emotion/cache@^11.11.0":
   version "11.11.0"
   resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-11.11.0.tgz#809b33ee6b1cb1a625fef7a45bc568ccd9b8f3ff"
   integrity sha512-P34z9ssTCBi3e9EI1ZsWpNHcfY1r09ZO0rZbRO2ob3ZQMnFI35jB536qoXbkdesr5EUhYi22anuEJuyxifaqAQ==
@@ -559,6 +566,33 @@
     js-yaml "^4.1.0"
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
+
+"@floating-ui/core@^1.0.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.6.0.tgz#fa41b87812a16bf123122bf945946bae3fdf7fc1"
+  integrity sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==
+  dependencies:
+    "@floating-ui/utils" "^0.2.1"
+
+"@floating-ui/dom@^1.6.1":
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.6.3.tgz#954e46c1dd3ad48e49db9ada7218b0985cee75ef"
+  integrity sha512-RnDthu3mzPlQ31Ss/BTwQ1zjzIhr3lk1gZB1OC56h/1vEtaXkESrOqL5fQVMfXpwGtRwX+YsZBdyHtJMQnkArw==
+  dependencies:
+    "@floating-ui/core" "^1.0.0"
+    "@floating-ui/utils" "^0.2.0"
+
+"@floating-ui/react-dom@^2.0.8":
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react-dom/-/react-dom-2.0.8.tgz#afc24f9756d1b433e1fe0d047c24bd4d9cefaa5d"
+  integrity sha512-HOdqOt3R3OGeTKidaLvJKcgg75S6tibQ3Tif4eyd91QnIJWr0NLvoXFpJA/j8HqkFSL68GDca9AuyWEHlhyClw==
+  dependencies:
+    "@floating-ui/dom" "^1.6.1"
+
+"@floating-ui/utils@^0.2.0", "@floating-ui/utils@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.1.tgz#16308cea045f0fc777b6ff20a9f25474dd8293d2"
+  integrity sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q==
 
 "@fontsource/open-sans@^4.2.2":
   version "4.5.13"
@@ -890,24 +924,23 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
-"@mui/base@5.0.0-alpha.116":
-  version "5.0.0-alpha.116"
-  resolved "https://registry.yarnpkg.com/@mui/base/-/base-5.0.0-alpha.116.tgz#c167a66b7232088b4bcd97ba36096a357c6e4fb9"
-  integrity sha512-VwhifWdrfHc4/ZdqRZ4Gf+7P39sovNN24By1YVZdvJ9fvp0Sr8sNftGUCjYXXz+xCXVBQDXvhfxMwZrj2MvJvA==
+"@mui/base@5.0.0-beta.37":
+  version "5.0.0-beta.37"
+  resolved "https://registry.yarnpkg.com/@mui/base/-/base-5.0.0-beta.37.tgz#0e7e0f28402391fcfbb05476d5acc6c4f2d817b1"
+  integrity sha512-/o3anbb+DeCng8jNsd3704XtmmLDZju1Fo8R2o7ugrVtPQ/QpcqddwKNzKPZwa0J5T8YNW3ZVuHyQgbTnQLisQ==
   dependencies:
-    "@babel/runtime" "^7.20.7"
-    "@emotion/is-prop-valid" "^1.2.0"
-    "@mui/types" "^7.2.3"
-    "@mui/utils" "^5.11.7"
-    "@popperjs/core" "^2.11.6"
-    clsx "^1.2.1"
+    "@babel/runtime" "^7.23.9"
+    "@floating-ui/react-dom" "^2.0.8"
+    "@mui/types" "^7.2.13"
+    "@mui/utils" "^5.15.11"
+    "@popperjs/core" "^2.11.8"
+    clsx "^2.1.0"
     prop-types "^15.8.1"
-    react-is "^18.2.0"
 
-"@mui/core-downloads-tracker@^5.11.7":
-  version "5.11.7"
-  resolved "https://registry.yarnpkg.com/@mui/core-downloads-tracker/-/core-downloads-tracker-5.11.7.tgz#b3a3aad64c6b69f6165d7a00c0d9cfeacbe357a2"
-  integrity sha512-lZgX7XQTk0zVcpwEa80r+T4y09dosnUxWvFPSikU/2Hh5wnyNOek8WfJwGCNsaRiXJHMi5eHY+z8oku4u5lgNw==
+"@mui/core-downloads-tracker@^5.15.11":
+  version "5.15.11"
+  resolved "https://registry.yarnpkg.com/@mui/core-downloads-tracker/-/core-downloads-tracker-5.15.11.tgz#dcaf6156880e81e4547237fb781700485453e964"
+  integrity sha512-JVrJ9Jo4gyU707ujnRzmE8ABBWpXd6FwL9GYULmwZRtfPg89ggXs/S3MStQkpJ1JRWfdLL6S5syXmgQGq5EDAw==
 
 "@mui/icons-material@^5.10.9":
   version "5.10.16"
@@ -916,70 +949,69 @@
   dependencies:
     "@babel/runtime" "^7.20.1"
 
-"@mui/material@^5.10.13":
-  version "5.11.7"
-  resolved "https://registry.yarnpkg.com/@mui/material/-/material-5.11.7.tgz#d460c7239013a57cc2aa3d2bbe14ba875b29d7cb"
-  integrity sha512-wDv7Pc6kMe9jeWkmCLt4JChd1lPc2u23JQHpB35L2VwQowpNFoDfIwqi0sYCnZTMKlRc7lza8LqwSwHl2G52Rw==
+"@mui/material@^5.15.11":
+  version "5.15.11"
+  resolved "https://registry.yarnpkg.com/@mui/material/-/material-5.15.11.tgz#4f42ee30443699ffb5836029c6d8464154eca603"
+  integrity sha512-FA3eEuEZaDaxgN3CgfXezMWbCZ4VCeU/sv0F0/PK5n42qIgsPVD6q+j71qS7/62sp6wRFMHtDMpXRlN+tT/7NA==
   dependencies:
-    "@babel/runtime" "^7.20.7"
-    "@mui/base" "5.0.0-alpha.116"
-    "@mui/core-downloads-tracker" "^5.11.7"
-    "@mui/system" "^5.11.7"
-    "@mui/types" "^7.2.3"
-    "@mui/utils" "^5.11.7"
-    "@types/react-transition-group" "^4.4.5"
-    clsx "^1.2.1"
-    csstype "^3.1.1"
+    "@babel/runtime" "^7.23.9"
+    "@mui/base" "5.0.0-beta.37"
+    "@mui/core-downloads-tracker" "^5.15.11"
+    "@mui/system" "^5.15.11"
+    "@mui/types" "^7.2.13"
+    "@mui/utils" "^5.15.11"
+    "@types/react-transition-group" "^4.4.10"
+    clsx "^2.1.0"
+    csstype "^3.1.3"
     prop-types "^15.8.1"
     react-is "^18.2.0"
     react-transition-group "^4.4.5"
 
-"@mui/private-theming@^5.11.7":
-  version "5.11.7"
-  resolved "https://registry.yarnpkg.com/@mui/private-theming/-/private-theming-5.11.7.tgz#e92b87d6ea68ae5a23d0f0d9d248361b889a98db"
-  integrity sha512-XzRTSZdc8bhuUdjablTNv3kFkZ/XIMlKkOqqJCU0G8W3tWGXpau2DXkafPd1ddjPhF9zF3qLKNGgKCChYItjgA==
+"@mui/private-theming@^5.15.11":
+  version "5.15.11"
+  resolved "https://registry.yarnpkg.com/@mui/private-theming/-/private-theming-5.15.11.tgz#4b9289b56b1ae0beb84e47bc9952f927b6e175ae"
+  integrity sha512-jY/696SnSxSzO1u86Thym7ky5T9CgfidU3NFJjguldqK4f3Z5S97amZ6nffg8gTD0HBjY9scB+4ekqDEUmxZOA==
   dependencies:
-    "@babel/runtime" "^7.20.7"
-    "@mui/utils" "^5.11.7"
+    "@babel/runtime" "^7.23.9"
+    "@mui/utils" "^5.15.11"
     prop-types "^15.8.1"
 
-"@mui/styled-engine@^5.11.0":
-  version "5.11.0"
-  resolved "https://registry.yarnpkg.com/@mui/styled-engine/-/styled-engine-5.11.0.tgz#79afb30c612c7807c4b77602cf258526d3997c7b"
-  integrity sha512-AF06K60Zc58qf0f7X+Y/QjaHaZq16znliLnGc9iVrV/+s8Ln/FCoeNuFvhlCbZZQ5WQcJvcy59zp0nXrklGGPQ==
+"@mui/styled-engine@^5.15.11":
+  version "5.15.11"
+  resolved "https://registry.yarnpkg.com/@mui/styled-engine/-/styled-engine-5.15.11.tgz#040181f31910e0f66d43a5c44fe89da06b34212b"
+  integrity sha512-So21AhAngqo07ces4S/JpX5UaMU2RHXpEA6hNzI6IQjd/1usMPxpgK8wkGgTe3JKmC2KDmH8cvoycq5H3Ii7/w==
   dependencies:
-    "@babel/runtime" "^7.20.6"
-    "@emotion/cache" "^11.10.5"
-    csstype "^3.1.1"
+    "@babel/runtime" "^7.23.9"
+    "@emotion/cache" "^11.11.0"
+    csstype "^3.1.3"
     prop-types "^15.8.1"
 
-"@mui/system@^5.11.7":
-  version "5.11.7"
-  resolved "https://registry.yarnpkg.com/@mui/system/-/system-5.11.7.tgz#5e550c621733a18cd437678f11dcd1c3468129d0"
-  integrity sha512-uGB6hBxGlAdlmbLdTtUZYNPXkgQGGnKxHdkRATqsu7UlCxNsc/yS5NCEWy/3c4pnelD1LDLD39WrntP9mwhfkQ==
+"@mui/system@^5.15.11":
+  version "5.15.11"
+  resolved "https://registry.yarnpkg.com/@mui/system/-/system-5.15.11.tgz#19cf1974f82f1dd38be1f162034efecadd765733"
+  integrity sha512-9j35suLFq+MgJo5ktVSHPbkjDLRMBCV17NMBdEQurh6oWyGnLM4uhU4QGZZQ75o0vuhjJghOCA1jkO3+79wKsA==
   dependencies:
-    "@babel/runtime" "^7.20.7"
-    "@mui/private-theming" "^5.11.7"
-    "@mui/styled-engine" "^5.11.0"
-    "@mui/types" "^7.2.3"
-    "@mui/utils" "^5.11.7"
-    clsx "^1.2.1"
-    csstype "^3.1.1"
+    "@babel/runtime" "^7.23.9"
+    "@mui/private-theming" "^5.15.11"
+    "@mui/styled-engine" "^5.15.11"
+    "@mui/types" "^7.2.13"
+    "@mui/utils" "^5.15.11"
+    clsx "^2.1.0"
+    csstype "^3.1.3"
     prop-types "^15.8.1"
 
-"@mui/types@^7.2.3":
-  version "7.2.3"
-  resolved "https://registry.yarnpkg.com/@mui/types/-/types-7.2.3.tgz#06faae1c0e2f3a31c86af6f28b3a4a42143670b9"
-  integrity sha512-tZ+CQggbe9Ol7e/Fs5RcKwg/woU+o8DCtOnccX6KmbBc7YrfqMYEYuaIcXHuhpT880QwNkZZ3wQwvtlDFA2yOw==
+"@mui/types@^7.2.13":
+  version "7.2.13"
+  resolved "https://registry.yarnpkg.com/@mui/types/-/types-7.2.13.tgz#d1584912942f9dc042441ecc2d1452be39c666b8"
+  integrity sha512-qP9OgacN62s+l8rdDhSFRe05HWtLLJ5TGclC9I1+tQngbssu0m2dmFZs+Px53AcOs9fD7TbYd4gc9AXzVqO/+g==
 
-"@mui/utils@^5.11.7":
-  version "5.11.7"
-  resolved "https://registry.yarnpkg.com/@mui/utils/-/utils-5.11.7.tgz#a343a5d375b4140c875bf4c96825c1a148994800"
-  integrity sha512-8uyNDeVHZA804Ego20Erv8TpxlbqTe/EbhTI2H1UYr4/RiIbBprat8W4Qqr2UQIsC/b3DLz+0RQ6R/E5BxEcLA==
+"@mui/utils@^5.15.11":
+  version "5.15.11"
+  resolved "https://registry.yarnpkg.com/@mui/utils/-/utils-5.15.11.tgz#a71804d6d6025783478fd1aca9afbf83d9b789c7"
+  integrity sha512-D6bwqprUa9Stf8ft0dcMqWyWDKEo7D+6pB1k8WajbqlYIRA8J8Kw9Ra7PSZKKePGBGWO+/xxrX1U8HpG/aXQCw==
   dependencies:
-    "@babel/runtime" "^7.20.7"
-    "@types/prop-types" "^15.7.5"
-    "@types/react-is" "^16.7.1 || ^17.0.0"
+    "@babel/runtime" "^7.23.9"
+    "@types/prop-types" "^15.7.11"
     prop-types "^15.8.1"
     react-is "^18.2.0"
 
@@ -1176,10 +1208,10 @@
     read-package-json-fast "^2.0.3"
     which "^2.0.2"
 
-"@popperjs/core@^2.11.6":
-  version "2.11.6"
-  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.6.tgz#cee20bd55e68a1720bdab363ecf0c821ded4cd45"
-  integrity sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==
+"@popperjs/core@^2.11.8":
+  version "2.11.8"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.8.tgz#6b79032e760a0899cd4204710beede972a3a185f"
+  integrity sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==
 
 "@seznam/compose-react-refs@^1.0.6":
   version "1.0.6"
@@ -1376,10 +1408,15 @@
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
-"@types/prop-types@*", "@types/prop-types@^15.7.5":
+"@types/prop-types@*":
   version "15.7.5"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.5.tgz#5f19d2b85a98e9558036f6a3cacc8819420f05cf"
   integrity sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==
+
+"@types/prop-types@^15.7.11":
+  version "15.7.11"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.11.tgz#2596fb352ee96a1379c657734d4b913a613ad563"
+  integrity sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==
 
 "@types/react-dom@^18.0.0", "@types/react-dom@^18.0.5":
   version "18.0.10"
@@ -1388,17 +1425,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-is@^16.7.1 || ^17.0.0":
-  version "17.0.3"
-  resolved "https://registry.yarnpkg.com/@types/react-is/-/react-is-17.0.3.tgz#2d855ba575f2fc8d17ef9861f084acc4b90a137a"
-  integrity sha512-aBTIWg1emtu95bLTLx0cpkxwGW3ueZv71nE2YFBpL8k/z5czEW8yYpOo8Dp+UUAFAtKwNaOsh/ioSeQnWlZcfw==
-  dependencies:
-    "@types/react" "*"
-
-"@types/react-transition-group@^4.4.5":
-  version "4.4.5"
-  resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.5.tgz#aae20dcf773c5aa275d5b9f7cdbca638abc5e416"
-  integrity sha512-juKD/eiSM3/xZYzjuzH6ZwpP+/lejltmiS3QEzV/vmb/Q8+HfDmxu+Baga8UEMGBqV88Nbg4l2hY/K2DkyaLLA==
+"@types/react-transition-group@^4.4.10":
+  version "4.4.10"
+  resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.10.tgz#6ee71127bdab1f18f11ad8fb3322c6da27c327ac"
+  integrity sha512-hT/+s0VQs2ojCX823m60m5f0sL5idt9SO6Tj6Dg+rdphGPIeJbJ6CxvBYkgkGKrYeDjvIpKTR38UzmtHJOGW3Q==
   dependencies:
     "@types/react" "*"
 
@@ -2044,10 +2074,10 @@ clone@^1.0.2:
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==
 
-clsx@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.2.1.tgz#0ddc4a20a549b59c93a4116bb26f5294ca17dc12"
-  integrity sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==
+clsx@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.0.tgz#e851283bcb5c80ee7608db18487433f7b23f77cb"
+  integrity sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==
 
 cmd-shim@^5.0.0:
   version "5.0.0"
@@ -2206,10 +2236,15 @@ cssstyle@^2.3.0:
   dependencies:
     cssom "~0.3.6"
 
-csstype@^3.0.2, csstype@^3.1.1:
+csstype@^3.0.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.1.tgz#841b532c45c758ee546a11d5bd7b7b473c8c30b9"
   integrity sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==
+
+csstype@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.3.tgz#d80ff294d114fb0e6ac500fbf85b60137d7eff81"
+  integrity sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==
 
 data-urls@^3.0.2:
   version "3.0.2"
@@ -5053,6 +5088,11 @@ regenerator-runtime@^0.13.11:
   version "0.13.11"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
   integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
+
+regenerator-runtime@^0.14.0:
+  version "0.14.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz#356ade10263f685dda125100cd862c1db895327f"
+  integrity sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==
 
 regexp.prototype.flags@^1.4.3:
   version "1.4.3"

--- a/components/yarn.lock
+++ b/components/yarn.lock
@@ -2517,6 +2517,11 @@ eslint-plugin-jest-dom@^4.0.3:
     "@testing-library/dom" "^8.11.1"
     requireindex "^1.2.0"
 
+eslint-plugin-react-hooks@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz#4c3e697ad95b77e93f8646aaa1630c1ba607edd3"
+  integrity sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==
+
 eslint-plugin-react@^7.28.0, eslint-plugin-react@^7.29.4:
   version "7.32.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.32.2.tgz#e71f21c7c265ebce01bcbc9d0955170c55571f10"

--- a/docs/src/componentDocs/DrawerRailItem/playground/PlaygroundPage.tsx
+++ b/docs/src/componentDocs/DrawerRailItem/playground/PlaygroundPage.tsx
@@ -75,7 +75,20 @@ const inputConfig: InputConfig = [
     },
 
     // Shared Props
-    ...sharedPropsConfig.filter((prop) => !['collapseIcon', 'expandIcon', 'nestedDivider'].includes(prop.id)),
+    ...sharedPropsConfig.filter(
+        (prop) =>
+            ![
+                'activeItemBackgroundShape',
+                'chevron',
+                'chevronColor',
+                'collapseIcon',
+                'expandIcon',
+                'hidePadding',
+                'disableActiveItemParentStyles',
+                'nestedBackgroundColor',
+                'nestedDivider',
+            ].includes(prop.id)
+    ),
 
     // Other Configuration
     {


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes https://github.com/etn-ccis/blui-react-component-library/issues/216.
Fixes https://github.com/etn-ccis/blui-react-component-library/issues/860.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- remove classes.xxx on all combined classes
- rename defaultClasses to generatedClasses
- update components where combine not needed

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

- New
![image](https://github.com/etn-ccis/blui-react-component-library/assets/119693939/21216a5c-cabf-4dbf-a83c-b25e96b05012)

- Old
![image](https://github.com/etn-ccis/blui-react-component-library/assets/119693939/0f598ddb-2fb4-417f-9481-98875aa02ff7)


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- git checkout bug/blui-5304-duplicated-classes
- yarn start:showcase
- open dev tools
- inspect alarms nav item
- verify BluiDrawerNavItem-title & BluiDrawerNavItem-nestedTitle are not duplicated.
- navigate to file demos/showcase/src/pages/contextual-page-templates/Dashboard.tsx
- after line 182 channelValue add ```classes={{ value: 'MyTestClass' }}``` and save
- inspect channelValue 
![image](https://github.com/etn-ccis/blui-react-component-library/assets/119693939/f7afbdf7-ba16-4226-82fb-99ed19eea1e5)
- verify MyTestClass is not duplicated
- test several other components and add custom classes

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

- 
