### PR TITLE
Added MenuListProps prop to user menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v6.3.1 (Unreleased)
+
+### Fixed
+
+-   Issue with `MenuListProps` in `<UserMenu>` component ([#893](https://github.com/etn-ccis/blui-react-component-library/issues/893)).
+
 ## v6.3.0 (April 12, 2023)
 
 ### Removed

--- a/components/package.json
+++ b/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@brightlayer-ui/react-components",
-    "version": "6.3.0",
+    "version": "6.3.1",
     "description": "React components for Brightlayer UI applications",
     "scripts": {
         "test": "jest src",

--- a/components/src/core/UserMenu/UserMenu.tsx
+++ b/components/src/core/UserMenu/UserMenu.tsx
@@ -291,8 +291,8 @@ const UserMenuRender: React.ForwardRefRenderFunction<unknown, UserMenuProps> = (
                 open={Boolean(anchorEl)}
                 anchorEl={anchorEl}
                 onClose={closeMenu}
+                MenuListProps={{ style: { padding: 0 }, ...MenuProps.MenuListProps }}
                 {...MenuProps}
-                MenuListProps={{ style: { padding: 0 } }}
             >
                 {printMenu()}
             </Menu>


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes # BLUI-6029 #893 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Added MenuListProps prop to user menu

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

- 
<img width="1792" alt="Screenshot 2024-09-07 at 1 20 51 AM" src="https://github.com/user-attachments/assets/193b15b1-becc-449f-aeae-d7aabfb6432b">


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- Pass `MenuProps={{ MenuListProps: { dataTestId: 'user-menu-one' } }}` to UserMenu component in showcase demo
- yarn start
- Inspect Usermenu to see data test id 

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
