### PR TITLE
added padding for text+icon in  drawer nav rail item

### DIFF
--- a/components/src/core/Drawer/DrawerRailItem/DrawerRailItem.tsx
+++ b/components/src/core/Drawer/DrawerRailItem/DrawerRailItem.tsx
@@ -329,7 +329,7 @@ const DrawerRailItemRender: React.ForwardRefRenderFunction<unknown, DrawerRailIt
             onClick={onClickAction}
             hasAction={hasAction}
             itemActive={active}
-            sx={sx}
+            sx={{ ...sx, padding: '8px 16px' }}
             {...RippleProps}
         >
             {/* Active Item Highlight */}
@@ -345,6 +345,7 @@ const DrawerRailItemRender: React.ForwardRefRenderFunction<unknown, DrawerRailIt
                 />
             )}
             {/* Icon */}
+
             {getIcon()}
             {/* Title */}
             {!condensed && (
@@ -357,6 +358,7 @@ const DrawerRailItemRender: React.ForwardRefRenderFunction<unknown, DrawerRailIt
                     {title}
                 </Title>
             )}
+
             {/* Divider */}
             {divider && <DrawerRailItemDivider className={generatedClasses.divider} />}
         </Root>


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes https://github.com/etn-ccis/blui-react-component-library/issues/987 .

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- updated padding for text+icon in  drawer nav rail item

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

- Before : 
![image](https://github.com/user-attachments/assets/22863b4d-fdd1-4a7f-b715-e71609420e40)



- After: 
![image](https://github.com/user-attachments/assets/749c5641-18e8-4c7b-b6c5-7cd6be93bd8d)




<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- Go to playground of Drawer Rail Item in Drawer section of cmponent.
- try to add long length title and see if padding is there or not.

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
